### PR TITLE
needed a version suffix that can be the empty string sometimes clean …

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -37,9 +37,16 @@ if(GIT_DESCRIBE MATCHES \"^v?([0-9]+)\\\\.([0-9]+)\\\\.([0-9]+)-([0-9]+)-g([0-9a
     # Add -dev- prefix if commits > 0 (development version, like neovim)
     if(NOT \"\${GIT_COMMITS_SINCE_TAG}\" STREQUAL \"0\")
         set(GIT_VERSION_STRING \"dev-\${GIT_COMMITS_SINCE_TAG}+g\${GIT_COMMIT_HASH}\${GIT_DIRTY_SUFFIX}\")
+        set(GIT_VERSION_SUFFIX \"-\")  # Separator for non-release versions
     else()
         # Exactly on tag (0 commits) - release version
-        set(GIT_VERSION_STRING \"\${GIT_DIRTY_SUFFIX}\")
+        if(\"\${GIT_DIRTY_SUFFIX}\" STREQUAL \"-dirty\")
+            set(GIT_VERSION_STRING \"dirty\")
+            set(GIT_VERSION_SUFFIX \"-\")  # Separator for dirty releases
+        else()
+            set(GIT_VERSION_STRING \"\")
+            set(GIT_VERSION_SUFFIX \"\")  # No separator for clean releases
+        endif()
     endif()
     # Override PROJECT_VERSION with tag version
     set(PROJECT_VERSION_MAJOR \"\${TAG_VERSION_MAJOR}\")
@@ -52,7 +59,13 @@ elseif(GIT_DESCRIBE MATCHES \"^v?([0-9]+)\\\\.([0-9]+)\\\\.([0-9]+)(-dirty)?\\\$
     set(TAG_VERSION_MINOR \"\${CMAKE_MATCH_2}\")
     set(TAG_VERSION_PATCH \"\${CMAKE_MATCH_3}\")
     set(GIT_DIRTY_SUFFIX \"\${CMAKE_MATCH_4}\")
-    set(GIT_VERSION_STRING \"\${GIT_DIRTY_SUFFIX}\")
+    if(\"\${GIT_DIRTY_SUFFIX}\" STREQUAL \"-dirty\")
+        set(GIT_VERSION_STRING \"dirty\")
+        set(GIT_VERSION_SUFFIX \"-\")  # Separator for dirty releases
+    else()
+        set(GIT_VERSION_STRING \"\")
+        set(GIT_VERSION_SUFFIX \"\")  # No separator for clean releases
+    endif()
     # Override PROJECT_VERSION with tag version
     set(PROJECT_VERSION_MAJOR \"\${TAG_VERSION_MAJOR}\")
     set(PROJECT_VERSION_MINOR \"\${TAG_VERSION_MINOR}\")
@@ -63,6 +76,7 @@ elseif(GIT_DESCRIBE MATCHES \"^([0-9a-f]+)(-dirty)?\\\$\")
     set(GIT_COMMIT_HASH \"\${CMAKE_MATCH_1}\")
     set(GIT_DIRTY_SUFFIX \"\${CMAKE_MATCH_2}\")
     set(GIT_VERSION_STRING \"dev-g\${GIT_COMMIT_HASH}\${GIT_DIRTY_SUFFIX}\")
+    set(GIT_VERSION_SUFFIX \"-\")  # Separator for development versions
     set(PROJECT_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
     set(PROJECT_VERSION_MINOR ${PROJECT_VERSION_MINOR})
     set(PROJECT_VERSION_PATCH ${PROJECT_VERSION_PATCH})
@@ -70,6 +84,7 @@ elseif(GIT_DESCRIBE MATCHES \"^([0-9a-f]+)(-dirty)?\\\$\")
 else()
     # Fallback - use version from project()
     set(GIT_VERSION_STRING \"unknown\")
+    set(GIT_VERSION_SUFFIX \"-\")  # Separator for unknown versions
     set(PROJECT_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
     set(PROJECT_VERSION_MINOR ${PROJECT_VERSION_MINOR})
     set(PROJECT_VERSION_PATCH ${PROJECT_VERSION_PATCH})

--- a/lib/version.h.in
+++ b/lib/version.h.in
@@ -13,7 +13,8 @@
 #define ASCII_CHAT_BUILD_DATE "@BUILD_DATE@"
 
 // Full version string like "v0.2.0-42+gf811525" (nvim-style)
-#define ASCII_CHAT_VERSION_FULL "v" ASCII_CHAT_VERSION_STRING "-" ASCII_CHAT_GIT_VERSION
+// On clean release tags, this will be just "v0.3.0" without trailing dash
+#define ASCII_CHAT_VERSION_FULL "v" ASCII_CHAT_VERSION_STRING "@GIT_VERSION_SUFFIX@" ASCII_CHAT_GIT_VERSION
 
 // Description tagline
 #define ASCII_CHAT_DESCRIPTION_EMOJI_L "💻📸"


### PR DESCRIPTION
…fresh new tagged and committed code will generate a nice clean version string without a trailing dash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes version strings omit the trailing dash on clean tags by adding `GIT_VERSION_SUFFIX` and updating the header to use it.
> 
> - **Versioning (CMake)**:
>   - Introduces `GIT_VERSION_SUFFIX` to control the separator: `"-"` for dev/dirty/unknown builds, `""` for clean release tags.
>   - Adjusts logic on exact tags to set `GIT_VERSION_STRING` to `"dirty"` when dirty and to empty when clean; keeps `dev-...` format for post-tag commits and `dev-g...` for hash-only states.
> - **Header (`lib/version.h.in`)**:
>   - Updates `ASCII_CHAT_VERSION_FULL` to use `@GIT_VERSION_SUFFIX@`, preventing a trailing dash on clean release tags; adds clarifying comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cbe8762955b7a5d801b7dfe8aaf1c93480b3df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->