### PR TITLE
default release log file goes in the tmp dir

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -606,7 +606,27 @@ asciichat_error_t options_init(int argc, char **argv, bool is_client) {
   // Static initializers don't work reliably in Windows DLLs created from OBJECT files
   // so we must initialize them explicitly here
   SAFE_SNPRINTF(opt_port, OPTIONS_BUFF_SIZE, "27224");
+
+// Set default log file paths for Release builds
+#ifdef NDEBUG
+  char temp_dir[256];
+  if (platform_get_temp_dir(temp_dir, sizeof(temp_dir))) {
+    SAFE_SNPRINTF(opt_log_file, OPTIONS_BUFF_SIZE, "%s%sascii-chat.%s.log", temp_dir,
+#if defined(_WIN32) || defined(WIN32)
+                  "\\",
+#else
+                  "/",
+#endif
+                  is_client ? "client" : "server");
+  } else {
+    // Fallback if platform_get_temp_dir fails
+    SAFE_SNPRINTF(opt_log_file, OPTIONS_BUFF_SIZE, "ascii-chat.log");
+  }
+#else
+  // Debug builds: No default log file (empty string)
   opt_log_file[0] = '\0';
+#endif
+
   opt_no_encrypt = 0;
   opt_encrypt_key[0] = '\0';
   opt_password[0] = '\0';

--- a/lib/platform/posix/system.c
+++ b/lib/platform/posix/system.c
@@ -857,6 +857,39 @@ asciichat_error_t platform_load_system_ca_certs(char **pem_data_out, size_t *pem
   return SET_ERRNO(ERROR_CRYPTO, "No CA certificate bundle found in standard locations");
 }
 
+/**
+ * @brief Get the system temporary directory path (POSIX implementation)
+ *
+ * Returns /tmp for Unix systems (Linux/macOS), verifying it exists and is writable.
+ *
+ * @param temp_dir Buffer to store the temporary directory path
+ * @param path_size Size of the buffer
+ * @return true on success, false on failure
+ */
+bool platform_get_temp_dir(char *temp_dir, size_t path_size) {
+  if (temp_dir == NULL || path_size == 0) {
+    return false;
+  }
+
+  // On Unix systems, /tmp is the standard temporary directory
+  const char *tmp = "/tmp";
+
+  // Check if buffer is large enough
+  if (strlen(tmp) >= path_size) {
+    return false;
+  }
+
+  // Verify the directory exists and is writable
+  if (access(tmp, W_OK) != 0) {
+    // /tmp doesn't exist or isn't writable
+    return false;
+  }
+
+  // Copy the path
+  SAFE_STRNCPY(temp_dir, tmp, path_size);
+  return true;
+}
+
 // Include cross-platform system utilities (binary PATH detection)
 #include "../system.c"
 

--- a/lib/platform/system.h
+++ b/lib/platform/system.h
@@ -511,3 +511,36 @@ void platform_cleanup_binary_path_cache(void);
  * @ingroup platform
  */
 bool platform_get_executable_path(char *exe_path, size_t path_size);
+
+/**
+ * @brief Get the system temporary directory path
+ *
+ * Retrieves the path to the system's temporary directory using
+ * platform-specific methods. Verifies the directory exists and is writable.
+ *
+ * Platform-specific implementations:
+ *   - Windows: %TEMP% or %TMP% environment variable, fallback to C:\Temp
+ *   - Linux/macOS: /tmp
+ *
+ * @param temp_dir Buffer to store the temporary directory path
+ * @param path_size Size of the buffer
+ * @return true on success (directory exists and is writable), false on failure
+ *
+ * @note Thread-safe
+ * @note Returned path does not include trailing directory separator
+ * @note Buffer should be at least 256 bytes to support typical paths
+ * @note Returns false if the directory doesn't exist or lacks write permission
+ *
+ * @par Example:
+ * @code{.c}
+ * char temp_dir[256];
+ * if (platform_get_temp_dir(temp_dir, sizeof(temp_dir))) {
+ *   // temp_dir is valid and writable
+ *   char log_path[512];
+ *   snprintf(log_path, sizeof(log_path), "%s/myapp.log", temp_dir);
+ * }
+ * @endcode
+ *
+ * @ingroup platform
+ */
+bool platform_get_temp_dir(char *temp_dir, size_t path_size);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets a default log file in the system temp directory for Release builds and introduces cross‑platform platform_get_temp_dir to support it.
> 
> - **Logging (options)**:
>   - In `options_init`, set `opt_log_file` by default (Release only) to temp dir: `ascii-chat.client.log` or `ascii-chat.server.log`; fallback to `ascii-chat.log` if temp lookup fails.
>   - Debug builds keep `opt_log_file` empty.
> - **Platform API**:
>   - Add `bool platform_get_temp_dir(char *temp_dir, size_t path_size)` to `lib/platform/system.h`.
>   - Implement POSIX version in `lib/platform/posix/system.c` returning `/tmp` if writable.
>   - Implement Windows version in `lib/platform/windows/system.c` using `%TEMP%`/`%TMP%` with fallback `C:\Temp`, verifying write access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370d7d6d4eff1cd276e5cae2c1d1f4553b09fb83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->