### PR TITLE
fix cmake deps cache bug that cursorbot noticed

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -119,7 +119,7 @@ if(WIN32)
     elseif(EXISTS "${CMAKE_SOURCE_DIR}/deps/bearssl")
         set(BEARSSL_SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/bearssl")
         # Build to cache directory to keep platform-specific builds separate
-        set(BEARSSL_BUILD_DIR "${DEPS_CACHE_BASE_DIR}/${CMAKE_BUILD_TYPE}/bearssl")
+        set(BEARSSL_BUILD_DIR "${DEPS_CACHE_DIR}/${CMAKE_BUILD_TYPE}/bearssl")
         # Windows uses bearssls.lib, Unix uses libbearssl.a
         set(BEARSSL_LIB "${BEARSSL_BUILD_DIR}/bearssls.lib")
 

--- a/cmake/Mimalloc.cmake
+++ b/cmake/Mimalloc.cmake
@@ -18,7 +18,7 @@
 if(USE_MIMALLOC)
     message(STATUS "Configuring mimalloc memory allocator...")
     set(MIMALLOC_SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/mimalloc-src")
-    set(MIMALLOC_BUILD_DIR "${DEPS_CACHE_BASE_DIR}/${CMAKE_BUILD_TYPE}/mimalloc")
+    set(MIMALLOC_BUILD_DIR "${DEPS_CACHE_DIR}/${CMAKE_BUILD_TYPE}/mimalloc")
 
     # Check if mimalloc library already exists in cache
     set(_MIMALLOC_LIB_PATH "${MIMALLOC_BUILD_DIR}/lib/mimalloc-static.lib")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix cache directory variable for BearSSL and mimalloc CMake builds to use `DEPS_CACHE_DIR`.
> 
> - **CMake/Deps cache paths**:
>   - Use `DEPS_CACHE_DIR` (instead of `DEPS_CACHE_BASE_DIR`) for build cache locations.
>     - `cmake/Dependencies.cmake`: BearSSL build dir `BEARSSL_BUILD_DIR` updated.
>     - `cmake/Mimalloc.cmake`: mimalloc build dir `MIMALLOC_BUILD_DIR` updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc260d5baa8ea7a87aa0eb3f30546a8ce0d145e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->