### PR TITLE
fix bug 2 deps 2 fix

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -119,7 +119,7 @@ if(WIN32)
     elseif(EXISTS "${CMAKE_SOURCE_DIR}/deps/bearssl")
         set(BEARSSL_SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/bearssl")
         # Build to cache directory to keep platform-specific builds separate
-        set(BEARSSL_BUILD_DIR "${DEPS_CACHE_DIR}/${CMAKE_BUILD_TYPE}/bearssl")
+        set(BEARSSL_BUILD_DIR "${DEPS_CACHE_DIR}/bearssl")
         # Windows uses bearssls.lib, Unix uses libbearssl.a
         set(BEARSSL_LIB "${BEARSSL_BUILD_DIR}/bearssls.lib")
 

--- a/cmake/Mimalloc.cmake
+++ b/cmake/Mimalloc.cmake
@@ -18,7 +18,7 @@
 if(USE_MIMALLOC)
     message(STATUS "Configuring mimalloc memory allocator...")
     set(MIMALLOC_SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/mimalloc-src")
-    set(MIMALLOC_BUILD_DIR "${DEPS_CACHE_DIR}/${CMAKE_BUILD_TYPE}/mimalloc")
+    set(MIMALLOC_BUILD_DIR "${DEPS_CACHE_DIR}/mimalloc")
 
     # Check if mimalloc library already exists in cache
     set(_MIMALLOC_LIB_PATH "${MIMALLOC_BUILD_DIR}/lib/mimalloc-static.lib")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves BearSSL and mimalloc build cache directories to build-type-agnostic paths under `DEPS_CACHE_DIR`.
> 
> - **CMake**:
>   - **BearSSL**: `BEARSSL_BUILD_DIR` now `${DEPS_CACHE_DIR}/bearssl` (removed `${CMAKE_BUILD_TYPE}` component).
>   - **mimalloc**: `MIMALLOC_BUILD_DIR` now `${DEPS_CACHE_DIR}/mimalloc` (removed `${CMAKE_BUILD_TYPE}` component).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a803bd08b79e97165325f9999a8c50f25e5792b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->