### PR TITLE
Add cpack installation docs to doxygen

### DIFF
--- a/docs/topics/build.dox
+++ b/docs/topics/build.dox
@@ -1084,6 +1084,63 @@
  * - Uninstall support
  * - Optional: Custom installer icon
  *
+ * @subsubsection build_installation_cpack_linux Linux Installation with CPack
+ *
+ * **Install from DEB package** (if `dpkg` is available):
+ * @code{.bash}
+ * cmake --build build --target package
+ * sudo dpkg -i build/packages/ascii-chat-<version>-Linux.deb
+ * ascii-chat --help
+ * @endcode
+ *
+ * **Install from RPM package** (if `rpmbuild` is available):
+ * @code{.bash}
+ * cmake --build build --target package
+ * sudo rpm -i build/packages/ascii-chat-<version>-Linux.rpm
+ * ascii-chat --version
+ * @endcode
+ *
+ * **Install from TGZ archive** (always available):
+ * @code{.bash}
+ * cmake --build build --target package
+ * sudo tar -xzf build/packages/ascii-chat-<version>-Linux.tar.gz -C /usr/local --strip-components=1
+ * ascii-chat --version
+ * @endcode
+ *
+ * @subsubsection build_installation_cpack_macos macOS Installation with CPack
+ *
+ * **Install from DMG** (if `hdiutil` is available):
+ * @code{.bash}
+ * cmake --build build --target package
+ * hdiutil attach build/packages/ascii-chat-<version>-macOS.dmg
+ * sudo cp -R "/Volumes/ascii-chat/ascii-chat.app" /Applications/
+ * hdiutil detach "/Volumes/ascii-chat"
+ * /Applications/ascii-chat.app/Contents/MacOS/ascii-chat --version
+ * @endcode
+ *
+ * **Install from TGZ archive** (always available):
+ * @code{.bash}
+ * cmake --build build --target package
+ * sudo tar -xzf build/packages/ascii-chat-<version>-macOS.tar.gz -C /usr/local --strip-components=1
+ * /usr/local/bin/ascii-chat --version
+ * @endcode
+ *
+ * @subsubsection build_installation_cpack_windows Windows Installation with CPack
+ *
+ * **Install with NSIS/EXE installer** (if `makensis` is available):
+ * @code{.powershell}
+ * cmake --build build --target package
+ * Start-Process -FilePath "build/packages/ascii-chat-<version>-win64.exe" -Wait
+ * ascii-chat --version
+ * @endcode
+ *
+ * **Install from ZIP archive** (always available):
+ * @code{.powershell}
+ * cmake --build build --target package
+ * Expand-Archive -Path "build/packages/ascii-chat-<version>-win64.zip" -DestinationPath "$Env:ProgramFiles\\ascii-chat"
+ * & "$Env:ProgramFiles\\ascii-chat\\bin\\ascii-chat.exe" --version
+ * @endcode
+ *
  * **Source Packages**:
  * @code{.bash}
  * # Generate source distribution package


### PR DESCRIPTION
Add CPack installation instructions to the build Doxygen topic page for each OS to complement the existing packaging overview.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bdcd06f-6850-4d0e-8946-ca0cc4ad5bc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5bdcd06f-6850-4d0e-8946-ca0cc4ad5bc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise Linux, macOS, and Windows CPack install steps (DEB/RPM/TGZ, DMG/TGZ, NSIS/ZIP) to `docs/topics/build.dox`.
> 
> - **Documentation**:
>   - **Build topic (`docs/topics/build.dox`)**:
>     - Adds OS-specific CPack installation sections:
>       - `build_installation_cpack_linux`: install via `DEB`, `RPM`, or `TGZ` with example commands.
>       - `build_installation_cpack_macos`: install via `DMG` or `TGZ` with example commands.
>       - `build_installation_cpack_windows`: install via `NSIS/EXE` or `ZIP` with example commands.
>     - Retains source package instructions and exclusions list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 646410b4e59a531195df5df7550dd5e91c1cf079. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->