### PR TITLE
Check documentation against code

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Run `ascii-chat client --help` to see all client options:
 **Misc:**
 - `-q --quiet`: Disable console logging (logs only to file)
 - `-S --snapshot`: Capture one frame and exit (useful for testing)
-- `-D --snapshot-delay SECONDS`: Delay before snapshot in seconds (default: 3.0/5.0)
+- `-D --snapshot-delay SECONDS`: Delay before snapshot in seconds (default: 3.0 on Linux/Windows, 4.0 on macOS)
 - `-L --log-file FILE`: Redirect logs to file
 - `-v --version`: Display version information
 - `-h --help`: Show help message
@@ -261,8 +261,12 @@ Run `ascii-chat client --help` to see all client options:
 Run `./bin/ascii-chat server --help` to see all server options:
 
 **Connection:**
-- `-a --address ADDRESS`: IPv4 address to bind to (default: 0.0.0.0)
+- `-a --address ADDRESS`: IPv4 address to bind to (default: 127.0.0.1)
+- `   --address6 ADDRESS`: IPv6 address to bind to (default: ::1)
 - `-p --port PORT`: TCP port to listen on (default: 27224)
+
+By default the server only listens on loopback for safety. Use `--address 0.0.0.0` (and/or `--address6 ::`) when you
+intentionally want to accept remote clients.
 
 **Display:**
 - `-P --palette TYPE`: ASCII palette: standard, blocks, digital, minimal, cool, custom (default: standard)
@@ -297,7 +301,7 @@ ascii-chat's crypto works like your web browser's HTTPS: the client and server p
 - Supports encrypted keys (prompts for passphrase or uses ssh-agent)
 - Supports auto-detection with `--key ssh` or `--key ssh:`
 - Supports GitHub public keys with `--key github:username`
-- Future support planned for: `gpg:keyid`, `github:username.gpg`
+  - Supports `gpg:keyid` and `github:username.gpg` for GPG keys in addition to SSH key files
 
 **Password-Based Encryption** (`--password`):
 - Simple password string for encrypting connections

--- a/lib/image2ascii/ascii.h
+++ b/lib/image2ascii/ascii.h
@@ -73,7 +73,7 @@
  * pixel brightness to ASCII characters.
  *
  * @note External variable (defined in ascii.c).
- * @note Default palette: " .:-=+*#%@$" (common ASCII art palette).
+ * @note Default palette: "   ...',;:clodxkO0KXNWM" (dark to light).
  *
  * @ingroup image2ascii
  */

--- a/lib/options.h
+++ b/lib/options.h
@@ -319,7 +319,9 @@ extern ASCIICHAT_API bool auto_height;
  * - **Client mode**: Address of the server to connect to
  * - **Server mode**: IPv4 address to bind to (use "0.0.0.0" for all interfaces)
  *
- * **Default**: `"localhost"` (both client and server)
+ * **Default**:
+ * - Client mode: `"localhost"`
+ * - Server mode: `"127.0.0.1"`
  *
  * **Supported formats**:
  * - IPv4 addresses: `"192.168.1.100"`, `"127.0.0.1"`
@@ -344,7 +346,9 @@ extern ASCIICHAT_API char opt_address[];
  * specific IPv6 interfaces. Can be used alongside `opt_address` for dual-stack
  * support.
  *
- * **Default**: Empty string (IPv6 binding disabled)
+ * **Default**:
+ * - Client mode: Empty string (IPv6 disabled)
+ * - Server mode: `"::1"`
  *
  * **Supported formats**:
  * - IPv6 addresses: `"::1"` (localhost), `"::"` (all interfaces), `"2001:db8::1"`


### PR DESCRIPTION
Update documentation to match current code behavior and defaults.

This PR corrects several discrepancies between the documentation and the actual implementation, including the server's default bind address (now `127.0.0.1` for safety), the status of GPG key support, the snapshot delay defaults, and the default ASCII palette string.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc680d78-c5b7-410b-8ee1-131505fa0f66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc680d78-c5b7-410b-8ee1-131505fa0f66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to reflect server IPv4/IPv6 loopback defaults, platform-specific snapshot delay, GPG key support, and the new default ASCII palette string.
> 
> - **Docs (README)**
>   - **Server connection defaults**: `--address` now defaults to `127.0.0.1`; adds `--address6` default `::1`; clarifies loopback-only default and how to bind all interfaces.
>   - **Client snapshot**: `--snapshot-delay` defaults clarified per OS (Linux/Windows: 3.0, macOS: 4.0).
>   - **Auth**: Documents support for `gpg:keyid` and `github:username.gpg` in `--key`.
> - **Header comments**
>   - `lib/image2ascii/ascii.h`: Updates default palette note to `"   ...',;:clodxkO0KXNWM"`.
>   - `lib/options.h`: Clarifies defaults for `opt_address` (client `"localhost"`, server `"127.0.0.1"`) and `opt_address6` (client empty, server `"::1"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1c0b96b634067410f3a56e9b9c778c03be440da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->