### PR TITLE
Fix crypto test failures and build

### DIFF
--- a/cmake/targets/Tests.cmake
+++ b/cmake/targets/Tests.cmake
@@ -199,6 +199,9 @@ if(BUILD_TESTS AND CRITERION_FOUND)
         # Add Criterion include directories
         target_include_directories(${test_exe_name} PRIVATE ${CRITERION_INCLUDE_DIRS})
 
+        # Define CRITERION_TEST for test environment detection
+        target_compile_definitions(${test_exe_name} PRIVATE CRITERION_TEST=1)
+
         # For musl builds, disable subprocess isolation (no forking)
         if(USE_MUSL)
             target_compile_definitions(${test_exe_name} PRIVATE CRITERION_NO_EARLY_EXIT=1)

--- a/lib/crypto/crypto.c
+++ b/lib/crypto/crypto.c
@@ -29,7 +29,11 @@ static const uint32_t CRYPTO_PACKET_AUTH_RESPONSE = 104;
 
 // Check if we're in a test environment
 static int is_test_environment(void) {
+#if defined(CRITERION_TEST) || defined(__CRITERION__) || defined(TESTING)
+  return 1; // Compile-time test environment detection
+#else
   return SAFE_GETENV("CRITERION_TEST") != NULL || SAFE_GETENV("TESTING") != NULL;
+#endif
 }
 
 // Initialize libsodium (thread-safe, idempotent)

--- a/lib/network/network.c
+++ b/lib/network/network.c
@@ -26,9 +26,13 @@
 
 // Check if we're in a test environment
 static int is_test_environment(void) {
+#if defined(CRITERION_TEST) || defined(__CRITERION__) || defined(TESTING)
+  return 1; // Compile-time test environment detection
+#else
   const char *criterion_test = SAFE_GETENV("CRITERION_TEST");
   const char *testing = SAFE_GETENV("TESTING");
   return criterion_test != NULL || testing != NULL;
+#endif
 }
 
 /**

--- a/lib/network/packet.c
+++ b/lib/network/packet.c
@@ -31,7 +31,11 @@
 
 // Check if we're in a test environment
 static int is_test_environment(void) {
+#if defined(CRITERION_TEST) || defined(__CRITERION__) || defined(TESTING)
+  return 1; // Compile-time test environment detection
+#else
   return SAFE_GETENV("CRITERION_TEST") != NULL || SAFE_GETENV("TESTING") != NULL;
+#endif
 }
 
 /**

--- a/lib/tests/globals.c
+++ b/lib/tests/globals.c
@@ -6,7 +6,16 @@
 
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include "options.h"
+
+/**
+ * @brief Test environment initialization (runs before main)
+ * Sets CRITERION_TEST environment variable so libraries can detect test mode at runtime.
+ */
+__attribute__((constructor)) static void init_test_environment(void) {
+  setenv("CRITERION_TEST", "1", 0); // Don't overwrite if already set
+}
 
 /**
  * Global shutdown flag referenced by lib/logging.c and lib/lock_debug.c


### PR DESCRIPTION
Fixes test_unit_crypto::rekey_initialization test by properly detecting test environment at runtime.

Changes:
- Add constructor function to set CRITERION_TEST env var in test globals
- Update is_test_environment() to check compile-time macros first
- Add CRITERION_TEST=1 define to all test targets in CMake
- Fixed runtime detection for production vs test thresholds

Test results:
- test_unit_crypto: 54/54 passing (was 53/54)  ✅
- test_unit_crypto_handshake: 14/16 passing (unchanged)
- test_unit_crypto_keys: minor 2-byte memory leak detected

The rekey_initialization test was failing because crypto_init() couldn't detect it was running in a test environment, so it used production rekey thresholds (1M packets/1 hour) instead of test thresholds (1K packets/30s).

Fixes #issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes test-environment detection via compile-time defines and a test init constructor, enabling correct test-time thresholds/timeouts.
> 
> - **Tests/CMake**:
>   - Define `CRITERION_TEST=1` for all test targets in `cmake/targets/Tests.cmake`.
> - **Test Runtime Init**:
>   - Add constructor in `lib/tests/globals.c` to set `CRITERION_TEST=1` at startup.
> - **Runtime Libraries**:
>   - Update `is_test_environment()` in `lib/crypto/crypto.c`, `lib/network/network.c`, and `lib/network/packet.c` to prefer compile-time macros (`CRITERION_TEST`, `__CRITERION__`, `TESTING`) with env-var fallback.
>   - Uses test-mode thresholds/timeouts when detected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e741ab66f2955f04b172cac46ae14be0a789d8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->