### PR TITLE
debug asan instrumentation

### DIFF
--- a/cmake/debug/run_instrumentation.sh
+++ b/cmake/debug/run_instrumentation.sh
@@ -449,6 +449,7 @@ echo "Headers copied to instrumented tree"
 extra_source_files=(
   "lib/platform/system.c"
   "lib/debug/lock.c"
+  "lib/debug/memory.c"
   "lib/platform/posix/system.c"
   "lib/platform/posix/mutex.c"
   "lib/platform/posix/thread.c"

--- a/cmake/init/BuildTypes.cmake
+++ b/cmake/init/BuildTypes.cmake
@@ -43,16 +43,13 @@ function(configure_build_type_post_project)
         configure_debug_memory(${USE_MIMALLOC} ${USE_MUSL} FALSE)
         configure_debug_build_flags("Debug")
 
-        if(ASCII_BUILD_WITH_INSTRUMENTATION)
-            message(STATUS "Debug instrumentation build: skipping sanitizers (incompatible with instrumentation pipeline)")
-        else()
-            # Configure sanitizers (automatically handles mimalloc conflicts)
-            configure_sanitizers(${USE_MIMALLOC} "Debug")
+        # Configure sanitizers (automatically handles mimalloc conflicts)
+        # Note: Sanitizers are compatible with instrumentation - they work at different stages
+        configure_sanitizers(${USE_MIMALLOC} "Debug")
 
-            # Platform-specific sanitizer runtime fixes
-            fix_macos_asan_runtime()
-            copy_asan_runtime_dll()
-        endif()
+        # Platform-specific sanitizer runtime fixes
+        fix_macos_asan_runtime()
+        copy_asan_runtime_dll()
 
     elseif(CMAKE_BUILD_TYPE STREQUAL "Dev")
         # Dev mode - debug WITHOUT sanitizers (faster iteration)

--- a/cmake/platform/Sanitizers.cmake
+++ b/cmake/platform/Sanitizers.cmake
@@ -59,6 +59,21 @@ endfunction()
 # Configure AddressSanitizer + UndefinedBehaviorSanitizer + extras
 function(configure_asan_ubsan_sanitizers)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        # Check if ASan runtime is available on Windows
+        set(ASAN_AVAILABLE TRUE)
+        if(WIN32)
+            get_filename_component(CLANG_DIR ${CMAKE_C_COMPILER} DIRECTORY)
+            get_filename_component(CLANG_ROOT ${CLANG_DIR} DIRECTORY)
+            file(GLOB_RECURSE ASAN_LIB "${CLANG_ROOT}/lib/clang/*/lib/*/clang_rt.asan_dynamic*.lib")
+            if(NOT ASAN_LIB)
+                set(ASAN_AVAILABLE FALSE)
+                message(WARNING "ASan runtime libraries not found in LLVM installation - sanitizers disabled")
+                message(STATUS "  Searched: ${CLANG_ROOT}/lib/clang/*/lib/*/clang_rt.asan_dynamic*.lib")
+                message(STATUS "  To enable sanitizers, install LLVM with sanitizer runtimes or use Dev build")
+                return()
+            endif()
+        endif()
+
         # Base debug flags (always supported)
         add_compile_options(-g -fno-omit-frame-pointer)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables ASan/UBSan in Debug builds (even with instrumentation), adds Windows ASan runtime detection, and copies lib/debug/memory.c during instrumentation.
> 
> - **Build System (CMake)**:
>   - **Debug Sanitizers**: Always configure sanitizers in `Debug` (no longer skipped for instrumentation) via `configure_sanitizers()` in `cmake/init/BuildTypes.cmake`.
>   - **Windows ASan Detection**: In `cmake/platform/Sanitizers.cmake`, detect presence of ASan runtime on Windows and disable sanitizers with a warning if not found.
>   - **Runtime Fixes**: Retains `fix_macos_asan_runtime()` and `copy_asan_runtime_dll()` calls for platform-specific linkage.
> - **Instrumentation Script**:
>   - **Extra Sources**: Adds `lib/debug/memory.c` to `extra_source_files` copied into the instrumented tree in `cmake/debug/run_instrumentation.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60848a62825427baefd403c6a5484052d8a418de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->