### PR TITLE
Doxygen awesome2

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -63,6 +63,7 @@ jobs:
         sed -e "s|@CMAKE_SOURCE_DIR@|$(pwd)|g" \
             -e "s|@CMAKE_BINARY_DIR@|$(pwd)/build|g" \
             -e "s|@PROJECT_VERSION@|${{ steps.version.outputs.version }}|g" \
+            -e "s|@AWESOME_CSS_DIR@|$(pwd)/deps/doxygen-awesome-css|g" \
             docs/Doxyfile.in > build/Doxyfile
 
     - name: Build documentation


### PR DESCRIPTION
make doxygen-awesome work when github action publishes the docs too

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Docs workflow now checks out submodules and injects the Doxygen Awesome CSS directory into the generated Doxyfile.
> 
> - **CI/CD (Docs Workflow)**:
>   - Enable `submodules: true` in `actions/checkout` for `build-docs`.
>   - Add `@AWESOME_CSS_DIR@` substitution in `sed` to point to `deps/doxygen-awesome-css` during Doxyfile generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aed61f48132c0db6bee6f308c8fd6d46feb6c393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->