### PR TITLE
feat(cmake): add Unix shared library versioning with lib/v* tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/ProjectConstants.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/init/Init.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/init/Options.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/install/Version.cmake)
-version_detect()  # Sets PROJECT_VERSION_FROM_GIT
+version_detect()          # Sets PROJECT_VERSION_FROM_GIT (app version from v* tags)
+library_version_detect()  # Sets ASCIICHAT_LIB_VERSION (library version from lib/v* tags)
 include(${CMAKE_SOURCE_DIR}/cmake/init/BuildConfiguration.cmake)
 
 # =============================================================================

--- a/cmake/targets/Libraries.cmake
+++ b/cmake/targets/Libraries.cmake
@@ -404,6 +404,10 @@ if(WIN32 AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "De
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}  # .so goes in lib/
         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}  # Import .lib goes in lib/
         WINDOWS_EXPORT_ALL_SYMBOLS FALSE  # Use generated .def file instead
+        # Windows: VERSION/SOVERSION embed version info in PE header (no symlinks)
+        # Library version is from lib/v* tags, separate from app version
+        VERSION ${ASCIICHAT_LIB_VERSION}
+        SOVERSION ${ASCIICHAT_LIB_VERSION_MAJOR}
     )
 
     # Explicitly set import library location for Windows
@@ -504,6 +508,13 @@ else()
     set_target_properties(ascii-chat-shared PROPERTIES
         OUTPUT_NAME "asciichat"
         POSITION_INDEPENDENT_CODE ON
+        # Unix shared library versioning: creates symlink chain
+        # libasciichat.so → libasciichat.so.X → libasciichat.so.X.Y.Z
+        # The SOVERSION is embedded as the SONAME in the ELF header
+        # At runtime, ld.so looks for the SONAME (libasciichat.so.X), not the linker name
+        # Library version is from lib/v* tags, separate from app version
+        VERSION ${ASCIICHAT_LIB_VERSION}
+        SOVERSION ${ASCIICHAT_LIB_VERSION_MAJOR}
     )
 
     if(ASCIICHAT_ENABLE_UNITY_BUILDS)


### PR DESCRIPTION
## Summary
- Implement proper Unix shared library versioning with symlink chain: `libasciichat.so → libasciichat.so.0 → libasciichat.so.0.1.0`
- Library version is tracked separately from app version using `lib/v*` git tags
- SONAME is embedded in ELF header so runtime linker finds the correct versioned library

## Changes
- Add `VERSION` and `SOVERSION` properties to `ascii-chat-shared` target
- Add `library_version_detect()` macro to detect highest `lib/v*` tag
- Update install rules to use `install(TARGETS)` for proper symlink handling
- Fix `Version.cmake` to support git worktrees

## Verification
```bash
$ ls -la build/lib/libasciichat*
libasciichat.so.0.1.0   (real file)
libasciichat.so.0 → libasciichat.so.0.1.0  (soname)
libasciichat.so → libasciichat.so.0        (linker name)

$ readelf -d build/lib/libasciichat.so.0.1.0 | grep SONAME
  SONAME: [libasciichat.so.0]

$ readelf -d build/bin/ascii-chat | grep asciichat
  NEEDED: [libasciichat.so.0]
```

## Test plan
- [x] Build shared library with `cmake --build build --target ascii-chat-shared`
- [x] Verify symlink chain is created correctly
- [x] Verify SONAME is embedded in ELF header
- [x] Verify executable links against soname (not linker name)
- [ ] Test installation with `cmake --install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)