### PR TITLE
Add log level command line argument

### DIFF
--- a/lib/options.h
+++ b/lib/options.h
@@ -938,6 +938,46 @@ extern ASCIICHAT_API unsigned short int opt_strip_ansi;
  */
 extern ASCIICHAT_API char opt_log_file[OPTIONS_BUFF_SIZE];
 
+/** @brief Log level threshold for console and file output
+ *
+ * Controls which log messages are displayed. Only messages at this level
+ * or more severe are shown.
+ *
+ * **Default**:
+ * - DEBUG in debug builds (when NDEBUG is not defined)
+ * - INFO in release builds (when NDEBUG is defined)
+ *
+ * **Command-line**: `--log-level <level>` (set minimum log level)
+ *
+ * **Valid log levels** (from most verbose to least):
+ * - `dev`: Development-level messages (most verbose)
+ * - `debug`: Debug messages
+ * - `info`: Informational messages
+ * - `warn`: Warning messages
+ * - `error`: Error messages
+ * - `fatal`: Fatal error messages (least verbose)
+ *
+ * **Example**: `--log-level warn` (show warnings and errors only)
+ *
+ * **Environment variable**: Can be overridden by `LOG_LEVEL` environment variable
+ * - Format: Same as command-line levels (case-insensitive)
+ * - Example: `LOG_LEVEL=debug ./ascii-chat server`
+ *
+ * **Interaction with --verbose**:
+ * - `--verbose` (or `-V`) decreases the log level threshold, showing more messages
+ * - Applied after `--log-level` option parsing
+ * - Each `-V` flag lowers the threshold by one level
+ * - Example: `--log-level warn -VV` would lower warn to debug level
+ *
+ * @note Log level is a global setting that applies to all logging output
+ * @note Option is available for both client and server modes
+ * @note Environment variable `LOG_LEVEL` takes precedence over default, but not command-line
+ * @note Default level is set based on build type (debug vs release)
+ *
+ * @ingroup options
+ */
+extern ASCIICHAT_API log_level_t opt_log_level;
+
 /** @} */
 
 /**

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -279,13 +279,13 @@ static int initialize_client_systems(bool shared_init_completed) {
       if (log_path_result != ASCIICHAT_OK || !validated_log_file || strlen(validated_log_file) == 0) {
         // Invalid log file path, fall back to default and warn
         (void)fprintf(stderr, "WARNING: Invalid log file path specified, using default 'client.log'\n");
-        log_init("client.log", LOG_DEBUG, true);
+        log_init("client.log", opt_log_level, true);
       } else {
-        log_init(validated_log_file, LOG_DEBUG, true);
+        log_init(validated_log_file, opt_log_level, true);
       }
       SAFE_FREE(validated_log_file);
     } else {
-      log_init("client.log", LOG_DEBUG, true);
+      log_init("client.log", opt_log_level, true);
     }
 
     // Initialize memory debugging if enabled


### PR DESCRIPTION
Implement configurable log level support with intelligent defaults:
- Default to DEBUG in debug builds (NDEBUG not defined)
- Default to INFO in release builds (NDEBUG defined)
- Support --log-level command-line argument with values: dev, debug, info, warn, error, fatal
- Respect LOG_LEVEL environment variable (existing functionality preserved)
- Interact properly with --verbose flag to increase verbosity further
- Update both client and server usage/help text
- Integrate with log_init() to apply log level at startup

Changes:
- Add opt_log_level global variable to options.h with comprehensive documentation
- Add --log-level option parsing to client and server options
- Add validate_log_level() function for parsing log level strings
- Update log_init() calls to use opt_log_level instead of hardcoded LOG_DEBUG
- Update usage functions to document --log-level option