### PR TITLE
Debug configuration code issues

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -791,7 +791,6 @@ asciichat_error_t options_init(int argc, char **argv, bool is_client) {
       if (create_path[0] == '\0') {
         create_path = NULL;
       }
-      (void)fprintf(stderr, "[DEBUG] options_init: Found --config-create=%s\n", create_path ? create_path : "(empty)");
       asciichat_error_t create_result = config_create_default(create_path);
       if (create_result != ASCIICHAT_OK) {
         (void)fprintf(stderr, "Failed to create config file: %s\n", asciichat_error_string(create_result));
@@ -811,8 +810,6 @@ asciichat_error_t options_init(int argc, char **argv, bool is_client) {
           create_path = argv[i + 1];
         }
       }
-      (void)fprintf(stderr, "[DEBUG] options_init: Found --config-create with path=%s\n",
-                    create_path ? create_path : "(NULL - using default location)");
       asciichat_error_t create_result = config_create_default(create_path);
       if (create_result != ASCIICHAT_OK) {
         (void)fprintf(stderr, "Failed to create config file: %s\n", asciichat_error_string(create_result));


### PR DESCRIPTION
… specifier

Fixes 5 bugs in config.c and options.c:

1. Use-after-free in config_create_default() (config.c:1073-1074)
   - SET_ERRNO_SYS was using dir_path AFTER it was freed with SAFE_FREE
   - Fix: call SET_ERRNO_SYS first, store result, then free and return

2. Incomplete config flag reset in config_load_and_apply() (config.c:965-969)
   - Only 3 of 26 config flags were being reset at end of function
   - This caused issues when config_load_and_apply was called multiple times
   - Fix: reset ALL 26 config_*_set flags

3. Integer format specifier mismatch (config.c:306)
   - Using %ld for int64_t which may be 32-bit long on some platforms
   - Fix: use %lld with cast to (long long) for consistency

4. Missing TOML_INT64 case for snapshot_delay (config.c:499-518)
   - Config file values like "snapshot_delay = 5" (integer) were silently ignored
   - Only TOML_FP64 (floats) and TOML_STRING were handled
   - Fix: add TOML_INT64 case to handle integer delay values

5. Debug print statements left in production code (config.c:994, options.c:794,814)
   - [DEBUG] fprintf statements should not appear in production builds
   - Fix: remove the debug print statements