### PR TITLE
Fix CI caching configuration

### DIFF
--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -33,12 +33,12 @@ inputs:
   cache-version:
     description: 'Version string used to invalidate both caches when inputs change.'
     required: false
-    default: v2
+    default: v3
 
 outputs:
   build-cache-key:
     description: 'Fully qualified cache key for the build directory.'
-    value: ${{ format('{0}-build-{1}-{2}-{3}-{4}', inputs.cache-version, runner.os, github.workflow, github.job, steps.cache-config.outputs.build_suffix) }}
+    value: ${{ format('{0}-build-{1}-{2}-{3}-{4}-{5}', inputs.cache-version, runner.os, runner.arch, github.workflow, github.job, steps.cache-config.outputs.build_suffix) }}
   build-cache-hit:
     description: 'Whether the build directory cache was restored.'
     value: ${{ steps.cache-build-dir.outputs.cache-hit }}
@@ -47,7 +47,7 @@ outputs:
     value: ${{ inputs.build-directory }}
   deps-cache-key:
     description: 'Fully qualified cache key for the dependency cache.'
-    value: ${{ format('{0}-deps-{1}-{2}', inputs.cache-version, runner.os, steps.cache-config.outputs.build_suffix) }}
+    value: ${{ format('{0}-deps-{1}-{2}-{3}', inputs.cache-version, runner.os, runner.arch, steps.cache-config.outputs.build_suffix) }}
   deps-cache-hit:
     description: 'Whether the dependency cache was restored.'
     value: ${{ steps.cache-deps-dir.outputs.cache-hit }}
@@ -59,7 +59,7 @@ outputs:
     value: ${{ inputs.deps-cache-directory }}
   ccache-cache-key:
     description: 'Fully qualified cache key for ccache.'
-    value: ${{ format('{0}-ccache-{1}-{2}', inputs.cache-version, runner.os, steps.cache-config.outputs.ccache_suffix) }}
+    value: ${{ format('{0}-ccache-{1}-{2}-{3}', inputs.cache-version, runner.os, runner.arch, steps.cache-config.outputs.ccache_suffix) }}
   ccache-cache-hit:
     description: 'Whether the ccache directory was restored.'
     value: ${{ steps.cache-ccache.outputs.cache-hit }}
@@ -112,11 +112,11 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.build-directory }}
-        key: ${{ format('{0}-build-{1}-{2}-{3}-{4}', inputs.cache-version, runner.os, github.workflow, github.job, steps.cache-config.outputs.build_suffix) }}
+        key: ${{ format('{0}-build-{1}-{2}-{3}-{4}-{5}', inputs.cache-version, runner.os, runner.arch, github.workflow, github.job, steps.cache-config.outputs.build_suffix) }}
         restore-keys: |
-          ${{ format('{0}-build-{1}-{2}-{3}-', inputs.cache-version, runner.os, github.workflow, github.job) }}
-          ${{ format('{0}-build-{1}-{2}-', inputs.cache-version, runner.os, github.workflow) }}
-          ${{ format('{0}-build-{1}-', inputs.cache-version, runner.os) }}
+          ${{ format('{0}-build-{1}-{2}-{3}-{4}-', inputs.cache-version, runner.os, runner.arch, github.workflow, github.job) }}
+          ${{ format('{0}-build-{1}-{2}-{3}-', inputs.cache-version, runner.os, runner.arch, github.workflow) }}
+          ${{ format('{0}-build-{1}-{2}-', inputs.cache-version, runner.os, runner.arch) }}
 
     - name: Restore dependency cache directory
       if: inputs.cache-deps == 'true'
@@ -124,9 +124,9 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.deps-cache-directory }}
-        key: ${{ format('{0}-deps-{1}-{2}', inputs.cache-version, runner.os, steps.cache-config.outputs.build_suffix) }}
+        key: ${{ format('{0}-deps-{1}-{2}-{3}', inputs.cache-version, runner.os, runner.arch, steps.cache-config.outputs.build_suffix) }}
         restore-keys: |
-          ${{ format('{0}-deps-{1}-', inputs.cache-version, runner.os) }}
+          ${{ format('{0}-deps-{1}-{2}-', inputs.cache-version, runner.os, runner.arch) }}
 
     - name: Restore ccache directory
       if: inputs.cache-ccache == 'true'
@@ -134,6 +134,6 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.ccache-directory }}
-        key: ${{ format('{0}-ccache-{1}-{2}', inputs.cache-version, runner.os, steps.cache-config.outputs.ccache_suffix) }}
+        key: ${{ format('{0}-ccache-{1}-{2}-{3}', inputs.cache-version, runner.os, runner.arch, steps.cache-config.outputs.ccache_suffix) }}
         restore-keys: |
-          ${{ format('{0}-ccache-{1}-', inputs.cache-version, runner.os) }}
+          ${{ format('{0}-ccache-{1}-{2}-', inputs.cache-version, runner.os, runner.arch) }}

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -187,7 +187,7 @@ runs:
         # Use computed key from cache-keys step (github.ref_name not available in composite actions)
         key: ${{ steps.cache-keys.outputs.ccache-key || steps.cache-keys-win.outputs.ccache-key }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-ccache-v1-
+          ${{ runner.os }}-${{ runner.arch }}-ccache-v2-
 
     # Set CCACHE_DIR to workspace-relative path for consistent caching
     - name: Configure ccache directory (Unix)

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,7 +53,7 @@ jobs:
         id: cache-build
         uses: ./.github/actions/cache-build
         with:
-          cache-version: v5
+          cache-version: v6
 
       - name: Clean build directory to force reconfigure
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,7 +44,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directory to force reconfigure
       run: |
@@ -105,14 +105,14 @@ jobs:
       with:
         build-directory: ${{ github.workspace }}/build_debug
         build-cache-key: performance-debug
-        cache-version: v5
+        cache-version: v6
     - name: Cache release build directory
       id: cache-build-release
       uses: ./.github/actions/cache-build
       with:
         build-directory: ${{ github.workspace }}/build_release
         build-cache-key: performance-release
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directories to force reconfigure
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
         build-cache-key: ${{ matrix.build_type }}
 
     - name: Clean build directory to force reconfigure
@@ -289,7 +289,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directory to force reconfigure
       run: |
@@ -404,7 +404,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directory to force reconfigure
       run: |
@@ -529,7 +529,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directory to force reconfigure
       run: |
@@ -624,7 +624,7 @@ jobs:
       id: cache-build
       uses: ./.github/actions/cache-build
       with:
-        cache-version: v5
+        cache-version: v6
 
     - name: Clean build directory to force reconfigure
       run: |


### PR DESCRIPTION
…ollution

- Add runner.arch to cache-build action's build, deps, and ccache keys
- Update cache-version from v5 to v6 in all workflows to invalidate old caches
- Fix ccache restore-key version mismatch in install-deps (v1 -> v2)
- Bump cache-build default version to v3

This prevents cache pollution between arm64 and amd64 runners which could cause build failures or incorrect binaries when caches are restored across different architectures.