### PR TITLE
Find and fix bugs

### DIFF
--- a/src/client/audio.c
+++ b/src/client/audio.c
@@ -444,6 +444,11 @@ int audio_client_init() {
   // Initialize PortAudio context using library function
   if (audio_init(&g_audio_context) != ASCIICHAT_OK) {
     log_error("Failed to initialize audio system");
+    // Clean up WAV writer if it was opened
+    if (g_wav_playback_received) {
+      wav_writer_close(g_wav_playback_received);
+      g_wav_playback_received = NULL;
+    }
     return -1;
   }
 
@@ -457,6 +462,11 @@ int audio_client_init() {
   if (!g_audio_pipeline) {
     log_error("Failed to create audio pipeline");
     audio_destroy(&g_audio_context);
+    // Clean up WAV writer if it was opened
+    if (g_wav_playback_received) {
+      wav_writer_close(g_wav_playback_received);
+      g_wav_playback_received = NULL;
+    }
     return -1;
   }
 
@@ -469,6 +479,11 @@ int audio_client_init() {
     client_audio_pipeline_destroy(g_audio_pipeline);
     g_audio_pipeline = NULL;
     audio_destroy(&g_audio_context);
+    // Clean up WAV writer if it was opened
+    if (g_wav_playback_received) {
+      wav_writer_close(g_wav_playback_received);
+      g_wav_playback_received = NULL;
+    }
     return -1;
   }
 
@@ -479,6 +494,11 @@ int audio_client_init() {
     g_audio_pipeline = NULL;
     audio_stop_playback(&g_audio_context);
     audio_destroy(&g_audio_context);
+    // Clean up WAV writer if it was opened
+    if (g_wav_playback_received) {
+      wav_writer_close(g_wav_playback_received);
+      g_wav_playback_received = NULL;
+    }
     return -1;
   }
 
@@ -515,8 +535,10 @@ int audio_start_thread() {
     // THREAD SAFETY FIX: Use timeout to prevent indefinite blocking
     int join_result = ascii_thread_join_timeout(&g_audio_capture_thread, NULL, 5000);
     if (join_result != 0) {
-      log_warn("Audio capture thread join timed out after 5s, forcing thread handle reset");
+      log_warn("Audio capture thread join timed out after 5s - thread may be deadlocked, "
+               "forcing thread handle reset (stuck thread resources will not be cleaned up)");
       // Thread is stuck - we can't safely reuse the handle, but we can reset our tracking
+      // This is a resource leak of the stuck thread but continuing is safer than hanging
     }
     g_audio_capture_thread_created = false;
   }

--- a/src/server/protocol.c
+++ b/src/server/protocol.c
@@ -1018,7 +1018,7 @@ void handle_audio_opus_batch_packet(client_info_t *client, const void *data, siz
   }
 
   if (!client->opus_decoder) {
-    log_error("Client %u: Opus decoder not initialized", atomic_load(&client->client_id));
+    disconnect_client_for_bad_data(client, "Opus decoder not initialized");
     return;
   }
 
@@ -1192,7 +1192,7 @@ void handle_audio_opus_packet(client_info_t *client, const void *data, size_t le
   }
 
   if (!client->opus_decoder) {
-    log_error("Client %u: Opus decoder not initialized", atomic_load(&client->client_id));
+    disconnect_client_for_bad_data(client, "Opus decoder not initialized");
     return;
   }
 


### PR DESCRIPTION
- Add WAV writer cleanup on error paths in audio_client_init()
- Improves error handling for Opus decoder initialization failures by disconnecting bad clients instead of silently logging errors
- Enhance logging for audio capture thread timeout to clarify that the thread may be deadlocked