### PR TITLE
Find and fix bugs

### DIFF
--- a/lib/audio/mixer.c
+++ b/lib/audio/mixer.c
@@ -316,6 +316,7 @@ mixer_t *mixer_create(int max_sources, int sample_rate) {
     SAFE_FREE(mixer->source_buffers);
     SAFE_FREE(mixer->source_ids);
     SAFE_FREE(mixer->source_active);
+    SAFE_FREE(mixer->mix_buffer);
     SAFE_FREE(mixer);
     return NULL;
   }

--- a/lib/config.c
+++ b/lib/config.c
@@ -1067,6 +1067,7 @@ asciichat_error_t config_create_default(const char *config_path) {
   asciichat_error_t validate_result =
       path_validate_user_path(config_path_expanded, PATH_ROLE_CONFIG_FILE, &validated_config_path);
   if (validate_result != ASCIICHAT_OK) {
+    SAFE_FREE(config_path_expanded);
     return validate_result;
   }
   SAFE_FREE(config_path_expanded);


### PR DESCRIPTION
…dation()

- Fix memory leak in mixer_create(): Add SAFE_FREE(mixer->mix_buffer) in ducking_init() error path (lib/audio/mixer.c:319). The mix_buffer allocated at line 288 was not freed when ducking_init() failed.

- Fix resource leak in config_load_with_validation(): Add SAFE_FREE(config_path_expanded) before returning error from path_validate_user_path() (lib/config.c:1070). The config_path_expanded allocated earlier was not freed on validation failure.