### PR TITLE
Fix audio quality issues and low volume

### DIFF
--- a/lib/audio/mixer.c
+++ b/lib/audio/mixer.c
@@ -73,7 +73,9 @@ void compressor_init(compressor_t *comp, float sample_rate) {
   comp->gain_lin = 1.0f;
 
   // Set default parameters
-  compressor_set_params(comp, -10.0f, 4.0f, 10.0f, 100.0f, 3.0f);
+  // Increased makeup gain from 3dB to 6dB for better audibility
+  // Reduced ratio from 4:1 to 3:1 to reduce aggressive compression artifacts
+  compressor_set_params(comp, -10.0f, 3.0f, 10.0f, 100.0f, 6.0f);
 }
 
 void compressor_set_params(compressor_t *comp, float threshold_dB, float ratio, float attack_ms, float release_ms,
@@ -308,7 +310,7 @@ mixer_t *mixer_create(int max_sources, int sample_rate) {
 
   // Set crowd scaling parameters
   mixer->crowd_alpha = 0.5f; // Square root scaling
-  mixer->base_gain = 1.0f;   // Unity gain - prevents clipping (soft_clip handles peaks)
+  mixer->base_gain = 1.5f;   // Increased from 1.0f for better audibility with soft clipping handling
 
   // Initialize processing
   if (ducking_init(&mixer->ducking, max_sources, (float)sample_rate) != ASCIICHAT_OK) {
@@ -569,10 +571,10 @@ int mixer_process(mixer_t *mixer, float *output, int num_samples) {
       float comp_gain = compressor_process_sample(&mixer->compressor, mix);
       mix *= comp_gain;
 
-      // Compressor provides +3dB makeup gain which is sufficient for audibility
-      // No additional gain boost needed - decoded Opus audio already has good levels (~0.3-0.7 peak)
-      // The 2x gain was causing clipping/distortion when input peaks hit 0.65+
-      output[frame_start + s] = soft_clip(mix, 0.95f);
+      // Compressor provides +6dB makeup gain for better audibility
+      // Soft clipping at 0.98f threshold provides headroom while maintaining clean sound
+      // Reduced aggressiveness compared to hard clipping
+      output[frame_start + s] = soft_clip(mix, 0.98f);
     }
   }
 
@@ -727,10 +729,10 @@ int mixer_process_excluding_source(mixer_t *mixer, float *output, int num_sample
       float comp_gain = compressor_process_sample(&mixer->compressor, mix);
       mix *= comp_gain;
 
-      // Compressor provides +3dB makeup gain which is sufficient for audibility
-      // No additional gain boost needed - decoded Opus audio already has good levels (~0.3-0.7 peak)
-      // The 2x gain was causing clipping/distortion when input peaks hit 0.65+
-      output[frame_start + s] = soft_clip(mix, 0.95f);
+      // Compressor provides +6dB makeup gain for better audibility
+      // Soft clipping at 0.98f threshold provides headroom while maintaining clean sound
+      // Reduced aggressiveness compared to hard clipping
+      output[frame_start + s] = soft_clip(mix, 0.98f);
     }
   }
 


### PR DESCRIPTION
…mpression

- Increased compressor makeup gain from 3dB to 6dB for better audibility
- Reduced compression ratio from 4:1 to 3:1 to minimize aggressive artifacts
- Increased mixer base gain from 1.0f to 1.5f for louder output
- Adjusted soft clipping threshold from 0.95f to 0.98f for cleaner sound

These changes address the buzzy and quiet audio issues:
- The 3dB makeup gain was too conservative, resulting in quiet audio
- 4:1 compression ratio was too aggressive, causing buzzing artifacts
- Increased base gain provides better overall volume without hard clipping
- Less aggressive soft clipping reduces harmonic distortion

Testing recommended before production deployment.