### PR TITLE
Remove FIX and CRITICAL FIX log prefixes

### DIFF
--- a/lib/platform/windows/cond.c
+++ b/lib/platform/windows/cond.c
@@ -50,7 +50,7 @@ int cond_wait(cond_t *cond, mutex_t *mutex) {
  * @param timeout_ms Timeout in milliseconds
  * @return 0 on success, ETIMEDOUT on timeout, -1 on other failure
  * @note The mutex is automatically released while waiting and reacquired before returning
- * @note CROSS-PLATFORM FIX: Returns ETIMEDOUT on timeout for POSIX compatibility
+ * @note Returns ETIMEDOUT on timeout for POSIX compatibility
  */
 int cond_timedwait(cond_t *cond, mutex_t *mutex, int timeout_ms) {
   if (!SleepConditionVariableCS(cond, mutex, (DWORD)timeout_ms)) {

--- a/lib/platform/windows/system.c
+++ b/lib/platform/windows/system.c
@@ -263,7 +263,7 @@ bool platform_set_console_ctrl_handler(console_ctrl_handler_t handler) {
  * @brief Get environment variable value
  * @param name Environment variable name
  * @return Variable value or NULL if not found
- * @note MEMORY FIX: Uses thread-local static buffer to avoid memory leaks.
+ * @note Uses thread-local static buffer to avoid memory leaks.
  *       The returned pointer is valid until the next call to platform_getenv
  *       from the same thread.
  */

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -314,7 +314,7 @@ static void sigint_handler(int sigint) {
   atomic_store(&g_server_should_exit, true);
 
   // STEP 2: Use write() for output (async-signal-safe)
-  // NOTE: printf() and fflush() are NOT async-signal-safe and can cause deadlocks
+  // printf() and fflush() are NOT async-signal-safe and can cause deadlocks
   // Use write() which is guaranteed to be safe in signal handlers
   const char *msg = "SIGINT received - shutting down server...\n";
   ssize_t unused = write(STDOUT_FILENO, msg, strlen(msg));


### PR DESCRIPTION
Replace all prefixed comments like "BUGFIX:", "CRITICAL FIX:", "THREAD SAFETY FIX:", "SECURITY FIX:", "MEMORY FIX:", "DEADLOCK FIX:", etc. with cleaner inline comments that preserve the actual meaning without unnecessary labels.

This improves readability by removing redundant prefixes while keeping all important context about why the code is written a certain way. Comments now flow more naturally from the code they document.

Changes affect:
- lib/: All core library files (audio, buffer, compression, crypto, network, platform, video, ringbuffer)
- src/: All application code (client and server)
- notes/: Documentation files

Total: 33 files updated, all FIX-style prefixes removed (76 insertions, 83 deletions)