### PR TITLE
Add logging rate limit constants

### DIFF
--- a/lib/audio/audio.c
+++ b/lib/audio/audio.c
@@ -56,10 +56,10 @@ static int duplex_callback(const void *inputBuffer, void *outputBuffer, unsigned
   // Log status flags
   if (statusFlags != 0) {
     if (statusFlags & paOutputUnderflow) {
-      log_warn_every(1000000, "PortAudio output underflow");
+      log_warn_every(LOG_RATE_FAST, "PortAudio output underflow");
     }
     if (statusFlags & paInputOverflow) {
-      log_warn_every(1000000, "PortAudio input overflow");
+      log_warn_every(LOG_RATE_FAST, "PortAudio input overflow");
     }
   }
 
@@ -161,7 +161,7 @@ static int output_callback(const void *inputBuffer, void *outputBuffer, unsigned
   }
 
   if (statusFlags & paOutputUnderflow) {
-    log_warn_every(1000000, "PortAudio output underflow (separate stream)");
+    log_warn_every(LOG_RATE_FAST, "PortAudio output underflow (separate stream)");
   }
 
   // Read from playback buffer → output (speaker)
@@ -232,7 +232,7 @@ static int input_callback(const void *inputBuffer, void *outputBuffer, unsigned 
   }
 
   if (statusFlags & paInputOverflow) {
-    log_warn_every(1000000, "PortAudio input overflow (separate stream)");
+    log_warn_every(LOG_RATE_FAST, "PortAudio input overflow (separate stream)");
   }
 
   // Process AEC3 with render reference from render_buffer
@@ -375,7 +375,7 @@ asciichat_error_t audio_ring_buffer_write(audio_ring_buffer_t *rb, const float *
     // Still not enough space after cleanup - drop some incoming samples
     int samples_dropped = samples - available;
     samples_to_write = available;
-    log_warn_every(1000000, "Audio buffer overflow: dropping %d of %d incoming samples (buffer_used=%d/%d)",
+    log_warn_every(LOG_RATE_FAST, "Audio buffer overflow: dropping %d of %d incoming samples (buffer_used=%d/%d)",
                    samples_dropped, samples, AUDIO_RING_BUFFER_SIZE - available, AUDIO_RING_BUFFER_SIZE);
   }
 
@@ -461,7 +461,7 @@ size_t audio_ring_buffer_read(audio_ring_buffer_t *rb, float *data, size_t sampl
   // Instead: always consume samples to prevent overflow, use silence for missing data
   if (rb->jitter_buffer_enabled && available < AUDIO_JITTER_LOW_WATER_MARK) {
     rb->underrun_count++;
-    log_warn_every(1000000,
+    log_warn_every(LOG_RATE_FAST,
                    "Audio buffer low #%u: only %zu samples available (low water mark: %d), padding with silence",
                    rb->underrun_count, available, AUDIO_JITTER_LOW_WATER_MARK);
     // Don't set jitter_buffer_filled = false - keep reading to prevent overflow

--- a/lib/audio/mixer.c
+++ b/lib/audio/mixer.c
@@ -624,7 +624,7 @@ int mixer_process_excluding_source(mixer_t *mixer, float *output, int num_sample
         int chunk = (i + MIXER_FRAME_SIZE > num_samples) ? (num_samples - i) : MIXER_FRAME_SIZE;
         audio_ring_buffer_read(mixer->source_buffers[exclude_index], discard_buffer, chunk);
       }
-      log_debug_every(5000000, "Mixer: Draining solo client %u buffer to prevent overflow", exclude_client_id);
+      log_debug_every(LOG_RATE_DEFAULT, "Mixer: Draining solo client %u buffer to prevent overflow", exclude_client_id);
     }
     active_mask = mask_without_excluded;
   }

--- a/lib/audio/opus_codec.c
+++ b/lib/audio/opus_codec.c
@@ -115,7 +115,7 @@ size_t opus_codec_encode(opus_codec_t *codec, const float *samples, int num_samp
 
   if (encoded_bytes == 0) {
     // DTX frame (silence) - encoder produced zero bytes
-    log_debug_every(100000, "Opus DTX frame (silence detected)");
+    log_debug_every(LOG_RATE_VERY_FAST, "Opus DTX frame (silence detected)");
   }
 
   return (size_t)encoded_bytes;
@@ -136,7 +136,7 @@ int opus_codec_decode(opus_codec_t *codec, const uint8_t *data, size_t data_len,
 
   // If data is NULL, use PLC (Packet Loss Concealment)
   if (!data || data_len == 0) {
-    log_debug_every(100000, "Opus PLC (Packet Loss Concealment)");
+    log_debug_every(LOG_RATE_VERY_FAST, "Opus PLC (Packet Loss Concealment)");
     int samples = opus_decode_float(codec->decoder, NULL, 0, out_samples, out_num_samples, 0);
     if (samples < 0) {
       SET_ERRNO(ERROR_AUDIO, "Opus PLC failed: %s", opus_strerror(samples));

--- a/lib/common.h
+++ b/lib/common.h
@@ -495,6 +495,9 @@ extern int g_max_fps;
  * @ingroup common
  */
 
+/** @brief Log rate limit: 0.1 seconds (100,000 microseconds) - for very high frequency operations */
+#define LOG_RATE_VERY_FAST (100000)
+
 /** @brief Log rate limit: 1 second (1,000,000 microseconds) */
 #define LOG_RATE_FAST (1000000)
 

--- a/lib/debug/lock.c
+++ b/lib/debug/lock.c
@@ -459,7 +459,7 @@ static void check_long_held_locks(void) {
       format_duration_ns(held_ns, duration_str, sizeof(duration_str));
 
       // Log warning with formatted duration
-      log_warn_every(1000000,
+      log_warn_every(LOG_RATE_FAST,
                      "Lock held for %s (threshold: 100ms) - %s at %p\n"
                      "  Acquired: %s:%d in %s()\n"
                      "  Thread ID: %llu",

--- a/lib/debug/memory.c
+++ b/lib/debug/memory.c
@@ -239,13 +239,13 @@ void debug_free(void *ptr, const char *file, int line) {
     }
 
     if (!found) {
-      log_warn_every(1000000, "Freeing untracked pointer %p at %s:%d", ptr, file, line);
+      log_warn_every(LOG_RATE_FAST, "Freeing untracked pointer %p at %s:%d", ptr, file, line);
       platform_print_backtrace(1);
     }
 
     mutex_unlock(&g_mem.mutex);
   } else {
-    log_warn_every(1000000, "Debug memory mutex unavailable while freeing %p at %s:%d", ptr, file, line);
+    log_warn_every(LOG_RATE_FAST, "Debug memory mutex unavailable while freeing %p at %s:%d", ptr, file, line);
   }
 
   if (found) {
@@ -417,7 +417,7 @@ void *debug_realloc(void *ptr, size_t size, const char *file, int line) {
 
     mutex_unlock(&g_mem.mutex);
   } else {
-    log_warn_every(1000000, "Debug memory mutex unavailable while reallocating %p at %s:%d", ptr, file, line);
+    log_warn_every(LOG_RATE_FAST, "Debug memory mutex unavailable while reallocating %p at %s:%d", ptr, file, line);
   }
 
   // Perform actual reallocation
@@ -495,7 +495,7 @@ void *debug_realloc(void *ptr, size_t size, const char *file, int line) {
 
     mutex_unlock(&g_mem.mutex);
   } else {
-    log_warn_every(1000000, "Debug memory mutex unavailable while updating realloc block %p -> %p at %s:%d", ptr,
+    log_warn_every(LOG_RATE_FAST, "Debug memory mutex unavailable while updating realloc block %p -> %p at %s:%d", ptr,
                    new_ptr, file, line);
   }
 

--- a/lib/network/packet.c
+++ b/lib/network/packet.c
@@ -442,7 +442,7 @@ int send_packet_secure(socket_t sockfd, packet_type_t type, const void *data, si
   // If no crypto context or crypto not ready, send unencrypted
   bool ready = crypto_ctx ? crypto_is_ready(crypto_ctx) : false;
   if (!crypto_ctx || !ready) {
-    log_warn_every(1000000, "CRYPTO_DEBUG: Sending packet type %d UNENCRYPTED (crypto_ctx=%p, ready=%d)", type,
+    log_warn_every(LOG_RATE_FAST, "CRYPTO_DEBUG: Sending packet type %d UNENCRYPTED (crypto_ctx=%p, ready=%d)", type,
                    (void *)crypto_ctx, ready);
     int result = packet_send(sockfd, type, final_data, final_len);
     if (compressed_data) {
@@ -521,7 +521,7 @@ int send_packet_secure(socket_t sockfd, packet_type_t type, const void *data, si
   }
 
   // Send as PACKET_TYPE_ENCRYPTED
-  log_debug_every(10000000, "CRYPTO_DEBUG: Sending encrypted packet (original type %d as PACKET_TYPE_ENCRYPTED)", type);
+  log_debug_every(LOG_RATE_SLOW, "CRYPTO_DEBUG: Sending encrypted packet (original type %d as PACKET_TYPE_ENCRYPTED)", type);
   int send_result = packet_send(sockfd, PACKET_TYPE_ENCRYPTED, ciphertext, ciphertext_len);
   buffer_pool_free(ciphertext, ciphertext_size);
 

--- a/lib/packet_queue.c
+++ b/lib/packet_queue.c
@@ -227,7 +227,7 @@ int packet_queue_enqueue(packet_queue_t *queue, packet_type_t type, const void *
         }
         node_pool_put(queue->node_pool, head);
 
-        log_debug_every(1000000, "Dropped packet from queue (full): type=%d, client=%u", type, client_id);
+        log_debug_every(LOG_RATE_FAST, "Dropped packet from queue (full): type=%d, client=%u", type, client_id);
       }
       // If CAS failed, another thread already dequeued - continue to enqueue
     }

--- a/src/client/capture.c
+++ b/src/client/capture.c
@@ -441,7 +441,7 @@ static void *webcam_capture_thread_func(void *arg) {
 
     // Log warning if frame took too long to capture
     if (capture_frame_count > 1 && frame_interval_us > lag_threshold_us) {
-      log_warn_every(1000000,
+      log_warn_every(LOG_RATE_FAST,
                      "CLIENT CAPTURE LAG: Frame captured %.1fms late (expected %.1fms, got %.1fms, actual fps: %.1f)",
                      (double)(frame_interval_us - expected_interval_us) / 1000.0, (double)expected_interval_us / 1000.0,
                      (double)frame_interval_us / 1000.0, 1000000.0 / (double)frame_interval_us);

--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -649,7 +649,7 @@ static void handle_audio_batch_packet(const void *data, size_t len) {
   // Clean up
   SAFE_FREE(samples);
 
-  log_debug_every(5000000, "Processed audio batch: %u samples from server", total_samples);
+  log_debug_every(LOG_RATE_DEFAULT, "Processed audio batch: %u samples from server", total_samples);
 }
 
 /**
@@ -688,7 +688,7 @@ static void handle_audio_opus_packet(const void *data, size_t len) {
   // Process decoded audio through audio subsystem
   audio_process_received_samples(samples, decoded_samples);
 
-  log_debug_every(5000000, "Processed Opus audio: %d decoded samples from %zu byte packet", decoded_samples, len);
+  log_debug_every(LOG_RATE_DEFAULT, "Processed Opus audio: %d decoded samples from %zu byte packet", decoded_samples, len);
 }
 
 /**
@@ -788,7 +788,7 @@ static void handle_audio_opus_batch_packet(const void *data, size_t len) {
     // Process decoded audio through audio subsystem
     audio_process_received_samples(all_samples, total_decoded_samples);
 
-    log_debug_every(5000000, "Processed Opus batch: %d decoded samples from %d frames", total_decoded_samples,
+    log_debug_every(LOG_RATE_DEFAULT, "Processed Opus batch: %d decoded samples from %d frames", total_decoded_samples,
                     frame_count);
   }
 

--- a/src/server/client.c
+++ b/src/server/client.c
@@ -1265,7 +1265,7 @@ void *client_send_thread_func(void *arg) {
                                          20, audio_packet_count, (crypto_context_t *)crypto_ctx);
             mutex_unlock(&client->send_mutex);
 
-            log_debug_every(1000000, "Sent Opus batch: %d frames (%zu bytes) to client %u", audio_packet_count,
+            log_debug_every(LOG_RATE_FAST, "Sent Opus batch: %d frames (%zu bytes) to client %u", audio_packet_count,
                             total_opus_size, client->client_id);
           } else {
             log_error("Failed to allocate buffer for Opus batch");
@@ -1302,7 +1302,7 @@ void *client_send_thread_func(void *arg) {
 
             SAFE_FREE(batched_audio);
 
-            log_debug_every(1000000, "Sent audio batch: %d packets (%zu samples) to client %u", audio_packet_count,
+            log_debug_every(LOG_RATE_FAST, "Sent audio batch: %d packets (%zu samples) to client %u", audio_packet_count,
                             total_samples, client->client_id);
           } else {
             log_error("Failed to allocate buffer for audio batch");
@@ -1400,7 +1400,7 @@ void *client_send_thread_func(void *arg) {
         mutex_lock(&client->send_mutex);
         send_packet_secure(client->socket, PACKET_TYPE_CLEAR_CONSOLE, NULL, 0, (crypto_context_t *)crypto_ctx);
         mutex_unlock(&client->send_mutex);
-        log_debug_every(1000000, "Client %u: Sent CLEAR_CONSOLE (grid changed %d → %d sources)", client->client_id,
+        log_debug_every(LOG_RATE_FAST, "Client %u: Sent CLEAR_CONSOLE (grid changed %d → %d sources)", client->client_id,
                         sent_sources, rendered_sources);
         atomic_store(&client->last_sent_grid_sources, rendered_sources);
         sent_something = true;
@@ -1415,7 +1415,7 @@ void *client_send_thread_func(void *arg) {
       if (frame->data && frame->size == 0) {
         // NOTE: This means the we're not ready to send ascii to the client and
         // should wait a little bit.
-        log_warn_every(1000000, "Client %u has no valid frame size: size=%zu", client->client_id, frame->size);
+        log_warn_every(LOG_RATE_FAST, "Client %u has no valid frame size: size=%zu", client->client_id, frame->size);
         platform_sleep_usec(1000); // 1ms sleep
         continue;
       }
@@ -1510,7 +1510,7 @@ void *client_send_thread_func(void *arg) {
         uint64_t step5_us = ((uint64_t)step5.tv_sec * 1000000 + (uint64_t)step5.tv_nsec / 1000) -
                             ((uint64_t)step4.tv_sec * 1000000 + (uint64_t)step4.tv_nsec / 1000);
         log_warn_every(
-            5000000,
+            LOG_RATE_DEFAULT,
             "SEND_THREAD: Frame send took %.2fms for client %u | Snapshot: %.2fms | Memcpy: %.2fms | CRC32: %.2fms | "
             "Header: %.2fms | send_packet_secure: %.2fms",
             frame_time_us / 1000.0, client->client_id, step1_us / 1000.0, step2_us / 1000.0, step3_us / 1000.0,

--- a/src/server/protocol.c
+++ b/src/server/protocol.c
@@ -1203,7 +1203,7 @@ void handle_audio_opus_packet(client_info_t *client, const void *data, size_t le
     return;
   }
 
-  log_debug_every(100000, "Client %u: Decoded Opus frame -> %d samples", atomic_load(&client->client_id),
+  log_debug_every(LOG_RATE_VERY_FAST, "Client %u: Decoded Opus frame -> %d samples", atomic_load(&client->client_id),
                   decoded_count);
 
   // Write decoded samples to client's incoming audio buffer

--- a/src/server/render.c
+++ b/src/server/render.c
@@ -561,7 +561,7 @@ void *client_video_render_thread(void *arg) {
             lag_counter++;
             if (lag_counter % 10 == 0) {
               log_warn_every(
-                  1000000,
+                  LOG_RATE_FAST,
                   "SERVER VIDEO LAG: Client %u frame rendered %.1fms late (expected %.1fms, got %.1fms, actual "
                   "fps: %.1f)",
                   thread_client_id, (float)(frame_interval_us - expected_interval_us) / 1000.0f,
@@ -603,7 +603,7 @@ void *client_video_render_thread(void *arg) {
       (void)write_time_us;
     } else {
       // No frame generated (probably no video sources) - this is normal, no error logging needed
-      log_debug_every(3000000, "Per-client render: No video sources available for client %u", client_id_snapshot);
+      log_debug_every(LOG_RATE_NORMAL, "Per-client render: No video sources available for client %u", client_id_snapshot);
     }
 
   skip_frame_generation:
@@ -792,7 +792,7 @@ void *client_audio_render_thread(void *arg) {
     struct timespec loop_start_time;
     (void)clock_gettime(CLOCK_MONOTONIC, &loop_start_time);
 
-    log_debug_every(10000000, "Audio render loop iteration for client %u", thread_client_id);
+    log_debug_every(LOG_RATE_SLOW, "Audio render loop iteration for client %u", thread_client_id);
 
     // Check for immediate shutdown
     if (atomic_load(&g_server_should_exit)) {
@@ -811,7 +811,7 @@ void *client_audio_render_thread(void *arg) {
     }
 
     if (!g_audio_mixer) {
-      log_info_every(1000000, "Audio render waiting for mixer (client %u)", thread_client_id);
+      log_info_every(LOG_RATE_FAST, "Audio render waiting for mixer (client %u)", thread_client_id);
       // Check shutdown flag while waiting
       if (atomic_load(&g_server_should_exit))
         break;
@@ -850,7 +850,7 @@ void *client_audio_render_thread(void *arg) {
           size_t available = audio_ring_buffer_available_read(g_audio_mixer->source_buffers[i]);
           if (available > 96000) { // Buffer > 50% full (2 seconds)
             samples_to_read = 960; // Double read to catch up (20ms worth)
-            log_debug_every(5000000, "Audio catchup for client %u: buffer has %zu samples, reading %d",
+            log_debug_every(LOG_RATE_DEFAULT, "Audio catchup for client %u: buffer has %zu samples, reading %d",
                             client_id_snapshot, available, samples_to_read);
             break;
           }
@@ -889,7 +889,7 @@ void *client_audio_render_thread(void *arg) {
         samples_mixed = max_samples_in_frame; // Only count samples we actually read
       }
 
-      log_debug_every(5000000, "Audio mixer DISABLED (--no-audio-mixer): simple mixing, samples=%d for client %u",
+      log_debug_every(LOG_RATE_DEFAULT, "Audio mixer DISABLED (--no-audio-mixer): simple mixing, samples=%d for client %u",
                       samples_mixed, client_id_snapshot);
     } else {
       // Use adaptive sample count in normal mixer mode
@@ -902,12 +902,12 @@ void *client_audio_render_thread(void *arg) {
                            ((uint64_t)mix_start_time.tv_sec * 1000000 + (uint64_t)mix_start_time.tv_nsec / 1000);
 
     if (mix_time_us > 2000) { // Log if mixing takes > 2ms
-      log_warn_every(5000000, "Slow mixer for client %u: took %lluus (%.2fms)", client_id_snapshot, mix_time_us,
+      log_warn_every(LOG_RATE_DEFAULT, "Slow mixer for client %u: took %lluus (%.2fms)", client_id_snapshot, mix_time_us,
                      (float)mix_time_us / 1000.0f);
     }
 
     // Debug logging every 100 iterations (disabled - can slow down audio rendering)
-    // log_debug_every(10000000, "Audio render for client %u: samples_mixed=%d", client_id_snapshot, samples_mixed);
+    // log_debug_every(LOG_RATE_SLOW, "Audio render for client %u: samples_mixed=%d", client_id_snapshot, samples_mixed);
 
     // DEBUG: Log samples mixed every iteration
     // NOTE: mixer_debug_count is now per-thread (not static), so each client thread has its own counter
@@ -939,7 +939,7 @@ void *client_audio_render_thread(void *arg) {
                              ((uint64_t)accum_start.tv_sec * 1000000 + (uint64_t)accum_start.tv_nsec / 1000);
 
     if (accum_time_us > 500) {
-      log_warn_every(5000000, "Slow accumulate for client %u: took %lluus", client_id_snapshot, accum_time_us);
+      log_warn_every(LOG_RATE_DEFAULT, "Slow accumulate for client %u: took %lluus", client_id_snapshot, accum_time_us);
     }
 
     // Only encode and send when we have accumulated a full Opus frame
@@ -984,7 +984,7 @@ void *client_audio_render_thread(void *arg) {
                               ((uint64_t)opus_start_time.tv_sec * 1000000 + (uint64_t)opus_start_time.tv_nsec / 1000);
 
       if (opus_time_us > 2000) { // Log if encoding takes > 2ms
-        log_warn_every(5000000, "Slow Opus encode for client %u: took %lluus (%.2fms), size=%d", client_id_snapshot,
+        log_warn_every(LOG_RATE_DEFAULT, "Slow Opus encode for client %u: took %lluus (%.2fms), size=%d", client_id_snapshot,
                        opus_time_us, (float)opus_time_us / 1000.0f, opus_size);
       }
 
@@ -1029,7 +1029,7 @@ void *client_audio_render_thread(void *arg) {
                                  ((uint64_t)queue_start.tv_sec * 1000000 + (uint64_t)queue_start.tv_nsec / 1000);
 
         if (queue_time_us > 500) {
-          log_warn_every(5000000, "Slow queue for client %u: took %lluus", client_id_snapshot, queue_time_us);
+          log_warn_every(LOG_RATE_DEFAULT, "Slow queue for client %u: took %lluus", client_id_snapshot, queue_time_us);
         }
 
         if (result < 0) {
@@ -1054,7 +1054,7 @@ void *client_audio_render_thread(void *arg) {
           // Log warning if packet took too long to process
           if (audio_packet_count > 1 && packet_interval_us > lag_threshold_us) {
             log_warn_every(
-                1000000,
+                LOG_RATE_FAST,
                 "SERVER AUDIO LAG: Client %u packet processed %.1fms late (expected %.1fms, got %.1fms, actual "
                 "fps: %.1f)",
                 thread_client_id, (float)(packet_interval_us - expected_interval_us) / 1000.0f,
@@ -1082,7 +1082,7 @@ void *client_audio_render_thread(void *arg) {
 
     if (loop_elapsed_us >= target_loop_us) {
       // Processing took longer than target - skip sleep but warn
-      log_warn_every(1000000, "Audio processing took %lluus (%.1fms) - exceeds target %lluus (%.1fms) for client %u",
+      log_warn_every(LOG_RATE_FAST, "Audio processing took %lluus (%.1fms) - exceeds target %lluus (%.1fms) for client %u",
                      loop_elapsed_us, (float)loop_elapsed_us / 1000.0f, target_loop_us, (float)target_loop_us / 1000.0f,
                      thread_client_id);
     } else {

--- a/src/server/stream.c
+++ b/src/server/stream.c
@@ -632,7 +632,7 @@ static void calculate_optimal_grid_layout(image_source_t *sources, int source_co
     float utilization = total_area_used / total_available_area;
 
     float test_cell_visual_aspect = (float)cell_width / ((float)cell_height * CHAR_ASPECT);
-    log_debug_every(3000000, "  Testing %dx%d: cell=%dx%d (visual aspect %.2f), utilization=%.1f%%", cols, rows,
+    log_debug_every(LOG_RATE_NORMAL, "  Testing %dx%d: cell=%dx%d (visual aspect %.2f), utilization=%.1f%%", cols, rows,
                     cell_width, cell_height, test_cell_visual_aspect, utilization * 100.0f);
 
     // Prefer configurations with better utilization


### PR DESCRIPTION
… constants

- Add LOG_RATE_VERY_FAST constant (100,000 microseconds = 0.1 seconds)
- Replace 18x 1000000 with LOG_RATE_FAST
- Replace 5x 100000 with LOG_RATE_VERY_FAST
- Replace 4x 3000000 with LOG_RATE_NORMAL
- Replace 8x 5000000 with LOG_RATE_DEFAULT
- Replace 4x 10000000 with LOG_RATE_SLOW
- Remove all hardcoded microsecond values from log_*_every() calls
- Standardize logging rate limiting across codebase (51 calls total)
- Improves code maintainability and consistency