### PR TITLE
Standardize utility imports across codebase

### DIFF
--- a/lib/crypto/keys/keys.c
+++ b/lib/crypto/keys/keys.c
@@ -9,9 +9,9 @@
 #include "ssh_keys.h"
 #include "gpg_keys.h"
 #include "https_keys.h"
-#include "../../common.h"
-#include "../../asciichat_errno.h"
-#include "../../util/path.h"
+#include "common.h"
+#include "asciichat_errno.h"
+#include "util/path.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/platform/system.c
+++ b/lib/platform/system.c
@@ -8,8 +8,8 @@
 // All necessary headers are already included by the parent files
 
 #include <stdatomic.h>
-#include "../common.h"
-#include "../util/fnv1a.h"
+#include "common.h"
+#include "util/fnv1a.h"
 
 // UBSan-safe hash wrapper for uthash (fnv1a uses 64-bit arithmetic, no overflow)
 // Note: uthash expects HASH_FUNCTION(keyptr, keylen, hashv) where hashv is an output parameter
@@ -23,7 +23,7 @@
     }                                                                                                                  \
   } while (0)
 
-#include "../util/uthash.h"
+#include "util/uthash.h"
 #include "log/logging.h"
 
 // Platform-specific binary suffix

--- a/lib/platform/windows/system.c
+++ b/lib/platform/windows/system.c
@@ -9,9 +9,9 @@
 #include "../abstraction.h"
 #include "../internal.h"
 #include "../socket.h"
-#include "../../common.h"
-#include "../../asciichat_errno.h"
-#include "../../util/path.h"
+#include "common.h"
+#include "asciichat_errno.h"
+#include "util/path.h"
 #include "../symbols.h"
 
 #include <dbghelp.h>


### PR DESCRIPTION
Replace relative path imports (e.g., ../../util/path.h) with direct absolute-style imports (util/path.h) leveraging CMake's configured include directories (${CMAKE_SOURCE_DIR}/lib). This standardization:

- Improves readability and maintainability
- Avoids path fragility when files move
- Makes all lib/ files independent of depth
- Consistent with other parts of the codebase

Affected files:
- lib/crypto/keys/keys.c: ../../common.h, ../../asciichat_errno.h, ../../util/path.h
- lib/platform/system.c: ../common.h, ../util/fnv1a.h, ../util/uthash.h
- lib/platform/windows/system.c: ../../common.h, ../../asciichat_errno.h, ../../util/path.h