### PR TITLE
Refactor code to use utility functions

### DIFF
--- a/src/tooling/panic/report.c
+++ b/src/tooling/panic/report.c
@@ -7,6 +7,7 @@
 #include "tooling/panic/instrument_log.h"
 
 #include "util/uthash.h"
+#include "util/parsing.h"
 
 #include <errno.h>
 #include <inttypes.h>
@@ -427,9 +428,9 @@ static bool parse_arguments(int argc, char **argv, report_config_t *config) {
       config->log_dir = optarg;
       break;
     case 't': {
-      errno = 0;
-      unsigned long long tid_value = strtoull(optarg, NULL, 10);
-      if (errno != 0) {
+      unsigned long long tid_value;
+      asciichat_error_t parse_result = parse_ulonglong(optarg, &tid_value, 0, ULLONG_MAX);
+      if (parse_result != ASCIICHAT_OK) {
         log_error("Invalid thread id: %s", optarg);
         return false;
       }


### PR DESCRIPTION
Improve code quality and consistency by using utility functions from lib/util/:

* src/tooling/panic/report.c:
  - Use parse_ulonglong() from util/parsing.h for thread ID parsing
  - Replaces manual strtoull() with range-validated parsing

* lib/options/options.c:
  - Use expand_path() from util/path.h for SSH key path expansion
  - Simplifies path handling and centralizes tilde expansion logic
  - Removes manual HOME/USERPROFILE environment variable handling

* lib/video/simd/ascii_simd.c:
  - Add util/overflow.h for safe overflow checking
  - Use checked_size_mul() for pixel count calculations in 4 benchmark functions
  - Improves robustness against integer overflow in image dimension calculations
  - Ensures consistent overflow handling across all SIMD benchmark functions

All refactorings maintain backward compatibility and improve code safety.