### PR TITLE
Refactor code to use utility functions

### DIFF
--- a/lib/crypto/handshake.c
+++ b/lib/crypto/handshake.c
@@ -9,6 +9,7 @@
 #include "buffer_pool.h"
 #include "common.h"
 #include "util/endian.h"
+#include "util/ip.h"
 #include "crypto.h"
 #include "crypto/crypto.h"
 #include "known_hosts.h"
@@ -518,16 +519,13 @@ asciichat_error_t crypto_handshake_client_key_exchange(crypto_handshake_context_
       socklen_t addr_len = sizeof(server_addr);
       if (getpeername(client_socket, (struct sockaddr *)&server_addr, &addr_len) == 0) {
         char ip_str[INET6_ADDRSTRLEN];
-        if (server_addr.ss_family == AF_INET) {
-          struct sockaddr_in *addr_in = (struct sockaddr_in *)&server_addr;
-          if (inet_ntop(AF_INET, &addr_in->sin_addr, ip_str, sizeof(ip_str))) {
-            SAFE_STRNCPY(ctx->server_ip, ip_str, sizeof(ctx->server_ip) - 1);
+        if (format_ip_address(server_addr.ss_family, (struct sockaddr *)&server_addr, ip_str, sizeof(ip_str)) == ASCIICHAT_OK) {
+          SAFE_STRNCPY(ctx->server_ip, ip_str, sizeof(ctx->server_ip) - 1);
+          if (server_addr.ss_family == AF_INET) {
+            struct sockaddr_in *addr_in = (struct sockaddr_in *)&server_addr;
             ctx->server_port = NET_TO_HOST_U16(addr_in->sin_port);
-          }
-        } else if (server_addr.ss_family == AF_INET6) {
-          struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)&server_addr;
-          if (inet_ntop(AF_INET6, &addr_in6->sin6_addr, ip_str, sizeof(ip_str))) {
-            SAFE_STRNCPY(ctx->server_ip, ip_str, sizeof(ctx->server_ip) - 1);
+          } else if (server_addr.ss_family == AF_INET6) {
+            struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)&server_addr;
             ctx->server_port = NET_TO_HOST_U16(addr_in6->sin6_port);
           }
         }

--- a/lib/platform/posix/system.c
+++ b/lib/platform/posix/system.c
@@ -10,6 +10,7 @@
 #include "../internal.h"
 #include "../../common.h" // For log_error()
 #include "../../asciichat_errno.h"
+#include "../../util/ip.h"
 #include "../symbols.h" // For symbol cache
 #include <unistd.h>
 #include <fcntl.h>
@@ -812,13 +813,13 @@ asciichat_error_t platform_resolve_hostname_to_ipv4(const char *hostname, char *
   }
 
   // Extract IPv4 address from first result
-  struct sockaddr_in *ipv4_addr = (struct sockaddr_in *)result->ai_addr;
-  if (inet_ntop(AF_INET, &(ipv4_addr->sin_addr), ipv4_out, (socklen_t)ipv4_out_size) == NULL) {
-    freeaddrinfo(result);
-    return SET_ERRNO_SYS(ERROR_NETWORK, "Failed to convert network address to string");
+  asciichat_error_t format_result = format_ip_address(result->ai_family, result->ai_addr, ipv4_out, ipv4_out_size);
+  freeaddrinfo(result);
+
+  if (format_result != ASCIICHAT_OK) {
+    return format_result;
   }
 
-  freeaddrinfo(result);
   return ASCIICHAT_OK;
 }
 

--- a/lib/util/ip.h
+++ b/lib/util/ip.h
@@ -175,6 +175,40 @@ int parse_ip_with_port(const char *input, char *ip_output, size_t ip_output_size
  */
 
 /**
+ * @brief Format IP address from socket address structure
+ * @param family Address family (AF_INET for IPv4 or AF_INET6 for IPv6)
+ * @param addr Socket address pointer (must not be NULL)
+ * @param output Output buffer for formatted IP address (must not be NULL)
+ * @param output_size Size of output buffer (must be > 0)
+ * @return ASCIICHAT_OK on success, error code on failure
+ *
+ * Formats an IP address from a socket address structure. Automatically handles
+ * both IPv4 and IPv6 addresses by extracting the address from the appropriate
+ * socket structure fields.
+ *
+ * OUTPUT FORMATS:
+ * - IPv4: "192.0.2.1"
+ * - IPv6: "2001:db8::1"
+ *
+ * @note Output buffer should be at least 64 bytes to accommodate any IPv6 address.
+ * @note For IPv4: addr should point to sockaddr_in, for IPv6: should point to sockaddr_in6.
+ * @note Returns error code on failure (invalid family, buffer too small, etc.).
+ *
+ * @par Example
+ * @code
+ * char ip_str[64];
+ * struct sockaddr_in addr;
+ * // ... initialize addr ...
+ * if (format_ip_address(AF_INET, &addr, ip_str, sizeof(ip_str)) == ASCIICHAT_OK) {
+ *     // ip_str contains the formatted IP address
+ * }
+ * @endcode
+ *
+ * @ingroup util
+ */
+asciichat_error_t format_ip_address(int family, const struct sockaddr *addr, char *output, size_t output_size);
+
+/**
  * @brief Format IP address with port number
  * @param ip IP address (without brackets, must not be NULL)
  * @param port Port number (0-65535)

--- a/lib/video/ansi_fast.c
+++ b/lib/video/ansi_fast.c
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "video/simd/ascii_simd.h"
 #include "ansi_fast.h"
+#include "util/math.h"
 #include <string.h>
 #include <time.h>
 #ifndef _WIN32
@@ -363,24 +364,12 @@ uint8_t rgb_to_16color_dithered(int r, int g, int b, int x, int y, int width, in
   }
 
   // Clamp values to [0, 255]
-  if (r < 0) {
-    r = 0;
-  } else if (r > 255) {
-    r = 255;
-  }
-  if (g < 0) {
-    g = 0;
-  } else if (g > 255) {
-    g = 255;
-  }
-  if (b < 0) {
-    b = 0;
-  } else if (b > 255) {
-    b = 255;
-  }
+  uint8_t r_clamped = clamp_rgb((int)r);
+  uint8_t g_clamped = clamp_rgb((int)g);
+  uint8_t b_clamped = clamp_rgb((int)b);
 
   // Find the closest 16-color match
-  uint8_t closest_color = rgb_to_16color((uint8_t)r, (uint8_t)g, (uint8_t)b);
+  uint8_t closest_color = rgb_to_16color(r_clamped, g_clamped, b_clamped);
 
   // Calculate quantization error if dithering is enabled
   if (error_buffer) {

--- a/src/client/server.c
+++ b/src/client/server.c
@@ -68,8 +68,8 @@
 #include "network/network.h"
 #include "network/av.h"
 #include "util/endian.h"
+#include "util/ip.h"
 #include "common.h"
-#include "util/endian.h"
 #include "display.h"
 #include "options/options.h"
 #include "video/palette.h"
@@ -463,14 +463,11 @@ int server_connection_establish(const char *address, int port, int reconnect_att
                                                                                        : "unknown protocol");
 
         // Extract server IP address for known_hosts
-        if (addr_iter->ai_family == AF_INET) {
-          struct sockaddr_in *addr_in = (struct sockaddr_in *)addr_iter->ai_addr;
-          inet_ntop(AF_INET, &addr_in->sin_addr, g_server_ip, sizeof(g_server_ip));
-        } else if (addr_iter->ai_family == AF_INET6) {
-          struct sockaddr_in6 *addr_in6 = (struct sockaddr_in6 *)addr_iter->ai_addr;
-          inet_ntop(AF_INET6, &addr_in6->sin6_addr, g_server_ip, sizeof(g_server_ip));
+        if (format_ip_address(addr_iter->ai_family, addr_iter->ai_addr, g_server_ip, sizeof(g_server_ip)) == ASCIICHAT_OK) {
+          log_debug("Resolved server IP: %s", g_server_ip);
+        } else {
+          log_warn("Failed to format server IP address");
         }
-        log_debug("Resolved server IP: %s", g_server_ip);
 
         goto connection_success; // Break out of both loops
       }


### PR DESCRIPTION
- Add format_ip_address() utility to consistently format IP addresses from socket structures
  - Wraps inet_ntop() calls with proper error handling
  - Supports both IPv4 and IPv6 addresses
  - Used in: client/server.c, server/main.c, platform/posix/system.c, platform/windows/system.c, and crypto/handshake.c

- Replace manual RGB clamping with clamp_rgb() utility in video/ansi_fast.c
  - Eliminates verbose if/else chains
  - More maintainable and consistent with other utility usage

These refactorings:
- Reduce code duplication across the codebase
- Improve maintainability by centralizing IP formatting logic
- Follow the project's philosophy of using lib/util/ utilities
- Result in cleaner, more readable code