### PR TITLE
Reorganize codebase and CMake configuration

### DIFF
--- a/lib/common/buffer_sizes.h
+++ b/lib/common/buffer_sizes.h
@@ -1,0 +1,78 @@
+/**
+ * @defgroup buffer_sizes Buffer Sizes
+ * @ingroup module_core
+ * @brief Standard buffer size constants
+ *
+ * @file buffer_sizes.h
+ * @brief Common buffer size definitions
+ * @ingroup buffer_sizes
+ * @addtogroup buffer_sizes
+ * @{
+ */
+
+#pragma once
+
+/**
+ * @brief Small buffer size (256 bytes)
+ *
+ * Used for short strings, error messages, and small temporary buffers.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_SMALL 256
+
+/**
+ * @brief Medium buffer size (512 bytes)
+ *
+ * Used for medium-length strings, paths, and intermediate buffers.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_MEDIUM 512
+
+/**
+ * @brief Large buffer size (1024 bytes)
+ *
+ * Used for longer strings, full paths, and larger temporary buffers.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_LARGE 1024
+
+/**
+ * @brief Extra large buffer size (2048 bytes)
+ *
+ * Used for very long strings, multiple paths, and large temporary buffers.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_XLARGE 2048
+
+/**
+ * @brief Extra extra large buffer size (4096 bytes)
+ *
+ * Used for maximum-length paths and very large temporary buffers.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_XXLARGE 4096
+
+/**
+ * @brief Extra extra extra large buffer size (8192 bytes)
+ *
+ * Used for extremely large buffers like exception messages and stack traces.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_XXXLARGE 8192
+
+/**
+ * @brief Huge buffer size (16kb)
+ *
+ * Used for huge buffers like stack traces and other system messages.
+ *
+ * @ingroup buffer_sizes
+ */
+#define BUFFER_SIZE_HUGE 16384
+
+/** @} */

--- a/lib/common/error_codes.h
+++ b/lib/common/error_codes.h
@@ -1,0 +1,249 @@
+/**
+ * @defgroup error_codes Error and Exit Codes
+ * @ingroup module_core
+ * @brief Error codes and status values for ascii-chat
+ *
+ * @file error_codes.h
+ * @brief Error and exit codes - unified status values (0-255)
+ * @ingroup error_codes
+ * @addtogroup error_codes
+ * @{
+ *
+ * Single enum for both function return values and process exit codes.
+ * Following Unix conventions: 0 = success, 1 = general error, 2 = usage error.
+ *
+ * Error codes are organized into ranges:
+ * - 0: Success
+ * - 1-2: Standard errors (general, usage)
+ * - 3-19: Initialization failures
+ * - 20-39: Hardware/Device errors
+ * - 40-59: Network errors
+ * - 60-79: Security/Crypto errors
+ * - 80-99: Runtime errors
+ * - 100-127: Signal/Crash handlers
+ * - 128-255: Reserved (128+N = terminated by signal N on Unix)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/* Undefine Windows macros that conflict with our enum values */
+#ifdef _WIN32
+#undef ERROR_BUFFER_OVERFLOW
+#undef ERROR_INVALID_STATE
+#undef ERROR_FILE_NOT_FOUND
+#endif
+
+/**
+ * @brief Error and exit codes - unified status values (0-255)
+ *
+ * Single enum for both function return values and process exit codes.
+ * Following Unix conventions: 0 = success, 1 = general error, 2 = usage error.
+ *
+ * @ingroup error_codes
+ */
+typedef enum {
+  /* Standard codes (0-2) - Unix conventions */
+  ASCIICHAT_OK = 0,  /**< Success */
+  ERROR_GENERAL = 1, /**< Unspecified error */
+  ERROR_USAGE = 2,   /**< Invalid command line arguments or options */
+
+  /* Initialization failures (3-19) */
+  ERROR_MEMORY = 3,        /**< Memory allocation failed (OOM) */
+  ERROR_CONFIG = 4,        /**< Configuration file or settings error */
+  ERROR_CRYPTO_INIT = 5,   /**< Cryptographic initialization failed */
+  ERROR_LOGGING_INIT = 6,  /**< Logging system initialization failed */
+  ERROR_PLATFORM_INIT = 7, /**< Platform-specific initialization failed */
+
+  /* Hardware/Device errors (20-39) */
+  ERROR_WEBCAM = 20,            /**< Webcam initialization or capture failed */
+  ERROR_WEBCAM_IN_USE = 21,     /**< Webcam is in use by another application */
+  ERROR_WEBCAM_PERMISSION = 22, /**< Webcam permission denied */
+  ERROR_AUDIO = 23,             /**< Audio device initialization or I/O failed */
+  ERROR_AUDIO_IN_USE = 24,      /**< Audio device is in use */
+  ERROR_TERMINAL = 25,          /**< Terminal initialization or capability detection failed */
+
+  /* Network errors (40-59) */
+  ERROR_NETWORK = 40,          /**< General network error */
+  ERROR_NETWORK_BIND = 41,     /**< Cannot bind to port (server) */
+  ERROR_NETWORK_CONNECT = 42,  /**< Cannot connect to server (client) */
+  ERROR_NETWORK_TIMEOUT = 43,  /**< Network operation timed out */
+  ERROR_NETWORK_PROTOCOL = 44, /**< Protocol violation or incompatible version */
+  ERROR_NETWORK_SIZE = 45,     /**< Network packet size error */
+
+  /* Session and protocol errors (46-55) */
+  ERROR_RATE_LIMITED = 46,        /**< Rate limit exceeded */
+  ERROR_SESSION_NOT_FOUND = 47,   /**< Session not found or expired */
+  ERROR_SESSION_FULL = 48,        /**< Session has reached max participants */
+  ERROR_INVALID_PASSWORD = 49,    /**< Incorrect password */
+  ERROR_INVALID_SIGNATURE = 50,   /**< Invalid cryptographic signature */
+  ERROR_ACDS_STRING_TAKEN = 51,   /**< Requested session string already in use (ACDS) */
+  ERROR_ACDS_STRING_INVALID = 52, /**< Invalid session string format (ACDS) */
+  ERROR_INTERNAL = 53,            /**< Internal server error */
+  ERROR_UNKNOWN_PACKET = 54,      /**< Unknown packet type received */
+
+  /* Security/Crypto errors (60-79) */
+  ERROR_CRYPTO = 60,              /**< Cryptographic operation failed */
+  ERROR_CRYPTO_KEY = 61,          /**< Key loading, parsing, or generation failed */
+  ERROR_CRYPTO_AUTH = 62,         /**< Authentication failed */
+  ERROR_CRYPTO_HANDSHAKE = 63,    /**< Cryptographic handshake failed */
+  ERROR_CRYPTO_VERIFICATION = 64, /**< Signature or key verification failed */
+
+  /* Runtime errors (80-99) */
+  ERROR_THREAD = 80,             /**< Thread creation or management failed */
+  ERROR_BUFFER = 81,             /**< Buffer allocation or overflow */
+  ERROR_BUFFER_FULL = 82,        /**< Buffer full */
+  ERROR_BUFFER_OVERFLOW = 83,    /**< Buffer overflow */
+  ERROR_DISPLAY = 84,            /**< Display rendering or output error */
+  ERROR_INVALID_STATE = 85,      /**< Invalid program state */
+  ERROR_INVALID_PARAM = 86,      /**< Invalid parameter */
+  ERROR_INVALID_FRAME = 87,      /**< Invalid frame data */
+  ERROR_RESOURCE_EXHAUSTED = 88, /**< System resources exhausted */
+  ERROR_FORMAT = 89,             /**< String formatting operation failed */
+  ERROR_STRING = 90,             /**< String manipulation operation failed */
+  ERROR_NOT_FOUND = 91,          /**< Resource not found in registry or lookup */
+
+  /* Signal/Crash handlers (100-127) */
+  ERROR_SIGNAL_INTERRUPT = 100, /**< Interrupted by signal (SIGINT, SIGTERM) */
+  ERROR_SIGNAL_CRASH = 101,     /**< Fatal signal (SIGSEGV, SIGABRT, etc.) */
+  ERROR_ASSERTION_FAILED = 102, /**< Assertion or invariant violation */
+
+  /* Compression errors (103-104) */
+  ERROR_COMPRESSION = 103,   /**< Compression operation failed */
+  ERROR_DECOMPRESSION = 104, /**< Decompression operation failed */
+
+  /* File system errors (105-109) */
+  ERROR_FILE_OPERATION = 105, /**< File or directory operation failed */
+  ERROR_FILE_NOT_FOUND = 106, /**< File or directory not found */
+
+  /* Process errors (110-119) */
+  ERROR_PROCESS_FAILED = 110, /**< Process execution or termination failed */
+
+  /* Reserved (128-255) - Should not be used */
+  /* 128+N typically means "terminated by signal N" on Unix systems */
+
+} asciichat_error_t;
+
+/**
+ * @brief Get human-readable string for error/exit code
+ * @param code Error code from asciichat_error_t enum
+ * @return Human-readable error string, or "Unknown error" for invalid codes
+ * @ingroup error_codes
+ */
+static inline const char *asciichat_error_string(asciichat_error_t code) {
+  switch (code) {
+  case ASCIICHAT_OK:
+    return "Success";
+  case ERROR_GENERAL:
+    return "General error";
+  case ERROR_USAGE:
+    return "Invalid command line usage";
+  case ERROR_MEMORY:
+    return "Memory allocation failed";
+  case ERROR_CONFIG:
+    return "Configuration error";
+  case ERROR_CRYPTO_INIT:
+    return "Cryptographic initialization failed";
+  case ERROR_LOGGING_INIT:
+    return "Logging initialization failed";
+  case ERROR_PLATFORM_INIT:
+    return "Platform initialization failed";
+  case ERROR_WEBCAM:
+    return "Webcam error";
+  case ERROR_WEBCAM_IN_USE:
+    return "Webcam in use by another application";
+  case ERROR_WEBCAM_PERMISSION:
+    return "Webcam permission denied";
+  case ERROR_AUDIO:
+    return "Audio device error";
+  case ERROR_AUDIO_IN_USE:
+    return "Audio device in use";
+  case ERROR_TERMINAL:
+    return "Terminal error";
+  case ERROR_NETWORK:
+    return "Network error";
+  case ERROR_NETWORK_BIND:
+    return "Cannot bind to network port";
+  case ERROR_NETWORK_CONNECT:
+    return "Cannot connect to server";
+  case ERROR_NETWORK_TIMEOUT:
+    return "Network timeout";
+  case ERROR_NETWORK_PROTOCOL:
+    return "Network protocol error";
+  case ERROR_NETWORK_SIZE:
+    return "Network packet size error";
+  case ERROR_RATE_LIMITED:
+    return "Rate limit exceeded";
+  case ERROR_SESSION_NOT_FOUND:
+    return "Session not found";
+  case ERROR_SESSION_FULL:
+    return "Session is full";
+  case ERROR_INVALID_PASSWORD:
+    return "Invalid password";
+  case ERROR_INVALID_SIGNATURE:
+    return "Invalid signature";
+  case ERROR_ACDS_STRING_TAKEN:
+    return "Session string already in use";
+  case ERROR_ACDS_STRING_INVALID:
+    return "Invalid session string";
+  case ERROR_INTERNAL:
+    return "Internal server error";
+  case ERROR_UNKNOWN_PACKET:
+    return "Unknown packet type";
+  case ERROR_CRYPTO:
+    return "Cryptographic error";
+  case ERROR_CRYPTO_KEY:
+    return "Cryptographic key error";
+  case ERROR_CRYPTO_AUTH:
+    return "Authentication failed";
+  case ERROR_CRYPTO_HANDSHAKE:
+    return "Cryptographic handshake failed";
+  case ERROR_CRYPTO_VERIFICATION:
+    return "Signature verification failed";
+  case ERROR_THREAD:
+    return "Thread error";
+  case ERROR_BUFFER:
+    return "Buffer error";
+  case ERROR_BUFFER_FULL:
+    return "Buffer full";
+  case ERROR_BUFFER_OVERFLOW:
+    return "Buffer overflow";
+  case ERROR_DISPLAY:
+    return "Display error";
+  case ERROR_INVALID_STATE:
+    return "Invalid program state";
+  case ERROR_INVALID_PARAM:
+    return "Invalid parameter";
+  case ERROR_INVALID_FRAME:
+    return "Invalid frame data";
+  case ERROR_RESOURCE_EXHAUSTED:
+    return "System resources exhausted";
+  case ERROR_FORMAT:
+    return "String formatting operation failed";
+  case ERROR_STRING:
+    return "String manipulation operation failed";
+  case ERROR_NOT_FOUND:
+    return "Resource not found";
+  case ERROR_SIGNAL_INTERRUPT:
+    return "Interrupted by signal";
+  case ERROR_SIGNAL_CRASH:
+    return "Terminated by fatal signal";
+  case ERROR_ASSERTION_FAILED:
+    return "Assertion failed";
+  case ERROR_COMPRESSION:
+    return "Compression operation failed";
+  case ERROR_DECOMPRESSION:
+    return "Decompression operation failed";
+  case ERROR_FILE_OPERATION:
+    return "File or directory operation failed";
+  case ERROR_FILE_NOT_FOUND:
+    return "File or directory not found";
+  case ERROR_PROCESS_FAILED:
+    return "Process execution or termination failed";
+  default:
+    return "Unknown error";
+  }
+}
+
+/** @} */

--- a/lib/common/limits.h
+++ b/lib/common/limits.h
@@ -1,0 +1,40 @@
+/**
+ * @defgroup limits Application Limits
+ * @ingroup module_core
+ * @brief Limits for clients, frame rates, display names, and other constraints
+ *
+ * @file limits.h
+ * @brief Application limits and constraints
+ * @ingroup limits
+ * @addtogroup limits
+ * @{
+ */
+
+#pragma once
+
+/* ============================================================================
+ * Multi-Client Constants
+ * ============================================================================ */
+
+/** @brief Maximum display name length in characters */
+#define MAX_DISPLAY_NAME_LEN 32
+
+/** @brief Maximum possible clients (static array size) - actual runtime limit set by --max-clients (1-32) */
+#define MAX_CLIENTS 32
+
+/** @brief Default maximum frame rate (frames per second) */
+#define DEFAULT_MAX_FPS 60
+
+/** @brief Runtime configurable maximum frame rate (can be overridden via environment or command line) */
+extern int g_max_fps;
+
+/** @brief Maximum frame rate macro (uses g_max_fps if set, otherwise DEFAULT_MAX_FPS) */
+#define MAX_FPS (g_max_fps > 0 ? g_max_fps : DEFAULT_MAX_FPS)
+
+/** @brief Frame interval in milliseconds based on MAX_FPS */
+#define FRAME_INTERVAL_MS (1000 / MAX_FPS)
+
+/** @brief Frame buffer capacity based on MAX_FPS */
+#define FRAME_BUFFER_CAPACITY (MAX_FPS / 4)
+
+/** @} */

--- a/lib/common/log_rates.h
+++ b/lib/common/log_rates.h
@@ -1,0 +1,37 @@
+/**
+ * @defgroup log_rates Logging Rate Limits
+ * @ingroup module_core
+ * @brief Standard rate limits for log_*_every() macros
+ *
+ * @file log_rates.h
+ * @brief Logging rate limit constants (in microseconds)
+ * @ingroup log_rates
+ * @addtogroup log_rates
+ * @{
+ *
+ * Standard rate limits for log_*_every() macros to reduce log spam
+ * in high-frequency code paths.
+ *
+ * Usage: log_debug_every(LOG_RATE_VIDEO_FRAME, "message")
+ *
+ * @ingroup log_rates
+ */
+
+#pragma once
+
+/** @brief Log rate limit: 0.1 seconds (100,000 microseconds) - for very high frequency operations */
+#define LOG_RATE_VERY_FAST (100000)
+
+/** @brief Log rate limit: 1 second (1,000,000 microseconds) */
+#define LOG_RATE_FAST (1000000)
+
+/** @brief Log rate limit: 3 seconds (3,000,000 microseconds) */
+#define LOG_RATE_NORMAL (3000000)
+
+/** @brief Log rate limit: 5 seconds (5,000,000 microseconds) - default for audio/video packets */
+#define LOG_RATE_DEFAULT (5000000)
+
+/** @brief Log rate limit: 10 seconds (10,000,000 microseconds) */
+#define LOG_RATE_SLOW (10000000)
+
+/** @} */

--- a/lib/common/protocol_constants.h
+++ b/lib/common/protocol_constants.h
@@ -1,0 +1,83 @@
+/**
+ * @defgroup protocol_constants Protocol Constants
+ * @ingroup module_core
+ * @brief Protocol version, feature flags, compression, and frame constants
+ *
+ * @file protocol_constants.h
+ * @brief Protocol version, features, compression, and frame flag constants
+ * @ingroup protocol_constants
+ * @addtogroup protocol_constants
+ * @{
+ */
+
+#pragma once
+
+/* ============================================================================
+ * Protocol Version Constants
+ * ============================================================================ */
+
+/** @brief Major protocol version number */
+#define PROTOCOL_VERSION_MAJOR 1
+
+/** @brief Minor protocol version number */
+#define PROTOCOL_VERSION_MINOR 0
+
+/* ============================================================================
+ * Feature Flags
+ * ============================================================================ */
+
+/** @brief Run-length encoding support flag */
+#define FEATURE_RLE_ENCODING 0x01
+
+/** @brief Delta frame encoding support flag */
+#define FEATURE_DELTA_FRAMES 0x02
+
+/* ============================================================================
+ * Compression Constants
+ * ============================================================================ */
+
+/** @brief No compression algorithm */
+#define COMPRESS_ALGO_NONE 0x00
+
+/** @brief zlib deflate compression algorithm */
+#define COMPRESS_ALGO_ZLIB 0x01
+
+/** @brief LZ4 fast compression algorithm */
+#define COMPRESS_ALGO_LZ4 0x02
+
+/** @brief zstd algorithm */
+#define COMPRESS_ALGO_ZSTD 0x03
+
+/* ============================================================================
+ * Frame Flags
+ * ============================================================================ */
+
+/** @brief Frame includes ANSI color codes */
+#define FRAME_FLAG_HAS_COLOR 0x01
+
+/** @brief Frame data is compressed */
+#define FRAME_FLAG_IS_COMPRESSED 0x02
+
+/** @brief Frame data is RLE compressed */
+#define FRAME_FLAG_RLE_COMPRESSED 0x04
+
+/** @brief Frame was stretched (aspect adjusted) */
+#define FRAME_FLAG_IS_STRETCHED 0x08
+
+/* ============================================================================
+ * Pixel Format Constants
+ * ============================================================================ */
+
+/** @brief RGB pixel format */
+#define PIXEL_FORMAT_RGB 0
+
+/** @brief RGBA pixel format */
+#define PIXEL_FORMAT_RGBA 1
+
+/** @brief BGR pixel format */
+#define PIXEL_FORMAT_BGR 2
+
+/** @brief BGRA pixel format */
+#define PIXEL_FORMAT_BGRA 3
+
+/** @} */

--- a/lib/common/shutdown.h
+++ b/lib/common/shutdown.h
@@ -1,0 +1,57 @@
+/**
+ * @defgroup shutdown Shutdown System
+ * @ingroup module_core
+ * @brief Clean shutdown detection without library accessing application state
+ *
+ * @file shutdown.h
+ * @brief Shutdown check system for clean library/application separation
+ * @ingroup shutdown
+ * @addtogroup shutdown
+ * @{
+ *
+ * Provides clean separation between library and application for shutdown
+ * detection. Library code should never directly access application state.
+ *
+ * Usage:
+ *   Application (server.c/client.c):
+ *     shutdown_register_callback(my_shutdown_check_fn);
+ *
+ *   Library code (logging.c, debug/lock.c, etc.):
+ *     if (shutdown_is_requested()) { return; }
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+/**
+ * @brief Shutdown check callback function type
+ * @return true if shutdown has been requested, false otherwise
+ * @ingroup shutdown
+ */
+typedef bool (*shutdown_check_fn)(void);
+
+/**
+ * @brief Register application's shutdown check function
+ * @param callback Function to call to check if shutdown has been requested
+ *
+ * @note Call this from main() to register the application's shutdown detection function.
+ *       Library code should use shutdown_is_requested() instead of accessing application state directly.
+ *
+ * @ingroup shutdown
+ */
+void shutdown_register_callback(shutdown_check_fn callback);
+
+/**
+ * @brief Check if shutdown has been requested
+ * @return true if shutdown has been requested, false otherwise
+ *
+ * @note Use this in library code to check for shutdown requests without accessing
+ *       application state directly. The callback must be registered first with
+ *       shutdown_register_callback().
+ *
+ * @ingroup shutdown
+ */
+bool shutdown_is_requested(void);
+
+/** @} */

--- a/lib/common/string_constants.h
+++ b/lib/common/string_constants.h
@@ -1,0 +1,87 @@
+/**
+ * @defgroup string_constants String Literal Constants
+ * @ingroup module_core
+ * @brief Common string literal constants for boolean and value comparisons
+ *
+ * @file string_constants.h
+ * @brief String literal constants
+ * @ingroup string_constants
+ * @addtogroup string_constants
+ * @{
+ */
+
+#pragma once
+
+/**
+ * @brief String literal: "0" (zero)
+ *
+ * Used for boolean comparisons and numeric string parsing.
+ *
+ * @ingroup string_constants
+ */
+#define STR_ZERO "0"
+
+/**
+ * @brief String literal: "1" (one)
+ *
+ * Used for boolean comparisons and numeric string parsing.
+ *
+ * @ingroup string_constants
+ */
+#define STR_ONE "1"
+
+/**
+ * @brief String literal: "false"
+ *
+ * Used for boolean string comparisons.
+ *
+ * @ingroup string_constants
+ */
+#define STR_FALSE "false"
+
+/**
+ * @brief String literal: "true"
+ *
+ * Used for boolean string comparisons.
+ *
+ * @ingroup string_constants
+ */
+#define STR_TRUE "true"
+
+/**
+ * @brief String literal: "off"
+ *
+ * Used for boolean string comparisons (disable/enable).
+ *
+ * @ingroup string_constants
+ */
+#define STR_OFF "off"
+
+/**
+ * @brief String literal: "on"
+ *
+ * Used for boolean string comparisons (enable/disable).
+ *
+ * @ingroup string_constants
+ */
+#define STR_ON "on"
+
+/**
+ * @brief String literal: "no"
+ *
+ * Used for boolean string comparisons.
+ *
+ * @ingroup string_constants
+ */
+#define STR_NO "no"
+
+/**
+ * @brief String literal: "yes"
+ *
+ * Used for boolean string comparisons.
+ *
+ * @ingroup string_constants
+ */
+#define STR_YES "yes"
+
+/** @} */


### PR DESCRIPTION
Split the 1069-line common.h into organized sub-headers in lib/common/:
- error_codes.h: Error enum and asciichat_error_string() function
- protocol_constants.h: Protocol version, features, compression, frame flags
- limits.h: MAX_CLIENTS, FPS, display name length constraints
- buffer_sizes.h: Standard buffer size constants
- log_rates.h: Logging rate limit constants for rate-limited logging
- shutdown.h: Shutdown detection system for clean library/app separation
- string_constants.h: String literal constants (STR_TRUE, STR_FALSE, etc.)

common.h now acts as a convenience header that includes all sub-headers, maintaining backward compatibility while organizing code by concern.

Improves code maintainability and reduces header complexity.