### PR TITLE
Merge in-memory and file-based logs with deduplication

### DIFF
--- a/lib/log/grep.c
+++ b/lib/log/grep.c
@@ -853,14 +853,9 @@ const char *grep_highlight_colored(const char *colored_text, const char *plain_t
         size_t plain_match_start = (size_t)(found - plain_text);
         size_t plain_match_end = plain_match_start + strlen(fixed_string_pattern);
 
-        // Map to colored text positions
-        // Apply the same fix as in single-match path: get position AT the start, not after it
-        size_t colored_match_start =
-            (plain_match_start == 0) ? 0 : map_plain_to_colored_pos(colored_text, plain_match_start - 1);
+        // Map to colored text positions (same as single-match path)
+        size_t colored_match_start = map_plain_to_colored_pos(colored_text, plain_match_start);
         size_t colored_match_end = map_plain_to_colored_pos(colored_text, plain_match_end);
-
-        fprintf(stderr, "GLOBAL_MATCH_PATH: colored_match_start=%zu, colored_match_end=%zu\n", colored_match_start,
-                colored_match_end);
 
         // Copy text before match
         if (colored_match_start > colored_pos) {


### PR DESCRIPTION
## Summary
This PR enhances the terminal screen rendering to merge logs from both the in-memory session buffer and the log file, providing a more complete view of chat history while avoiding duplicate entries.

## Key Changes

- **Log merging in terminal_screen_render()**: When not in grep mode, the renderer now:
  - Retrieves logs from the in-memory session buffer as before
  - Optionally tails the configured log file (last 100KB) if specified
  - Merges and deduplicates entries from both sources using `log_file_parser_merge_and_dedupe()`
  - Ensures color initialization before processing file logs
  - Caps the final merged result at `SESSION_LOG_BUFFER_SIZE` to prevent buffer overflow

- **Added dependencies**: Imported `file_parser.h`, `logging.h`, and `options.h` headers to support file parsing and option retrieval

- **Fixed grep highlighting bug**: Corrected the position mapping logic in `grep_highlight_colored()` to consistently use the same calculation method for both single and multiple match paths, removing the special case that was causing incorrect highlighting. Also removed debug fprintf statement.

## Implementation Details

- The log file tailing is limited to 100KB to balance completeness with performance
- File entries are capped at `SESSION_LOG_BUFFER_SIZE / 2` to leave room for buffer entries in the merge
- Proper memory cleanup is performed for intermediate buffers (buffer_entries, file_entries) after merging
- The merge operation handles deduplication to prevent showing the same message twice if it exists in both sources

https://claude.ai/code/session_01YHQcHBjm1vX26GC5SrhhJH