### PR TITLE
Fix grep UI positioning to use correct terminal row

### DIFF
--- a/lib/ui/terminal_screen.c
+++ b/lib/ui/terminal_screen.c
@@ -389,7 +389,7 @@ void terminal_screen_render(const terminal_screen_config_t *config) {
     // positioning command and the grep input line rendering.
     char grep_ui_buffer[512];
     int pos = snprintf(grep_ui_buffer, sizeof(grep_ui_buffer), "\x1b[%d;1H\x1b[0m\x1b[K",
-                       g_cached_term_size.rows - 1);
+                       g_cached_term_size.rows);
 
     // Validate snprintf succeeded and produced expected output
     if (pos > 0 && pos < (int)sizeof(grep_ui_buffer) - 256) {


### PR DESCRIPTION
## Summary
Corrected the grep UI buffer positioning calculation in the terminal screen rendering to use the correct row number.

## Changes
- Changed the grep UI positioning from `g_cached_term_size.rows - 1` to `g_cached_term_size.rows` in the ANSI escape sequence
- This ensures the grep input line is positioned at the last row of the terminal instead of one row above it

## Details
The grep UI is rendered using an ANSI cursor positioning command (`\x1b[row;colH`). The previous implementation positioned it at `rows - 1`, which would place it one row above the actual bottom of the terminal. The corrected value uses `rows` directly, which properly aligns with terminal row numbering (1-indexed) to position the UI at the final visible row.

https://claude.ai/code/session_01R74nH9f5653tZTbZg4T4JV