### PR TITLE
fix(codeowners): replace literal \n with real newlines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+# Code owners\n* @Arvuno

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-# Code owners\n* @Arvuno
+# Code owners
+* @Arvuno

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/Arvuno/ascii-chat/actions/workflows/ci.yml/badge.svg)](https://github.com/Arvuno/ascii-chat/actions)
 # 💻📸 ascii-chat 🔡💬 Video chat in your terminal
 
 🌐 **[ascii-chat.com](https://ascii-chat.com)** - Homepage, installation, and documentation


### PR DESCRIPTION
The current `.github/CODEOWNERS` file contains a literal `\n` (backslash + n) sequence on line 1 instead of an actual newline. As a result, the ownership rule on line 2 (`* @Arvuno`) is parsed as part of the header comment by GitHub and never takes effect.

**Fix:** rewrite the file with proper LF newlines.

Detected by CodeRabbit AI review on PR #437 / #438. No code changes.