### PR TITLE
fix: correct includes for ssse3 optimization

### DIFF
--- a/lib/video/ascii/common.c
+++ b/lib/video/ascii/common.c
@@ -23,11 +23,11 @@
 #elif SIMD_SUPPORT_AVX2
 #include <ascii-chat/video/ascii/avx2.h>
 #elif SIMD_SUPPORT_SSSE3
-#include <ascii-chat/video/ascii/ssse3/foreground.h>
+#include <ascii-chat/video/ascii/ssse3.h>
 #elif SIMD_SUPPORT_SSE2
-#include <ascii-chat/video/ascii/sse2/foreground.h>
+#include <ascii-chat/video/ascii/sse2.h>
 #elif SIMD_SUPPORT_SVE
-#include <ascii-chat/video/ascii/sve/foreground.h>
+#include <ascii-chat/video/ascii/sve.h>
 #endif
 
 // Default luminance palette initialization lifecycle

--- a/lib/video/ascii/ssse3/color.c
+++ b/lib/video/ascii/ssse3/color.c
@@ -12,10 +12,10 @@
 
 #include <tmmintrin.h>
 
-#include <ascii-chat/video/ascii/ssse3/foreground.h>
-#include <ascii-chat/video/ascii/ascii_simd.h>
+#include <ascii-chat/video/ascii/ssse3.h>
+#include <ascii-chat/video/ascii/ascii.h>
 #include <ascii-chat/common.h>
-#include <ascii-chat/output_buffer.h>
+#include <ascii-chat/video/ascii/output_buffer.h>
 #include <ascii-chat/util/overflow.h>
 
 static inline uint8_t rgb_to_256color_ssse3(uint8_t r, uint8_t g, uint8_t b) {

--- a/lib/video/ascii/ssse3/mono.c
+++ b/lib/video/ascii/ssse3/mono.c
@@ -12,10 +12,10 @@
 
 #include <tmmintrin.h>
 
-#include <ascii-chat/video/ascii/ssse3/foreground.h>
-#include <ascii-chat/video/ascii/ascii_simd.h>
+#include <ascii-chat/video/ascii/ssse3.h>
+#include <ascii-chat/video/ascii/ascii.h>
 #include <ascii-chat/common.h>
-#include <ascii-chat/output_buffer.h>
+#include <ascii-chat/video/ascii/output_buffer.h>
 #include <ascii-chat/util/overflow.h>
 
 //=============================================================================


### PR DESCRIPTION
This PR allows for the current code to compile using SSSE3 optimization.

Basically, it catches up to the changes made in the `#include`s for video ASCII:

* `ascii-chat/video/ascii/ssse3/foreground.h` --> `ascii-chat/video/ascii/ssse3.h`.
    * Also included for `sse2` and `sve` in `lib/video/ascii/common.c`.
* `ascii-chat/video/ascii/ascii_simd.h` --> `ascii-chat/video/ascii/ascii.h`.
* `ascii-chat/output_buffer.h` --> `ascii-chat/video/ascii/output_buffer.h`.
